### PR TITLE
Fix error in IPI 2.3 and activate OICRs in performance indicators.

### DIFF
--- a/marlo-data/src/main/java/org/cgiar/ccafs/marlo/config/APConstants.java
+++ b/marlo-data/src/main/java/org/cgiar/ccafs/marlo/config/APConstants.java
@@ -790,6 +790,7 @@ public final class APConstants {
   public static final int CLARISA_AVALIABLE_INFO_YEAR = 2018;
 
   public static final String IGNORE_NEWER_YEARS = "ignoreNewer";
+  public static final String DELIVERABLE_CRP_PROGRAM_OUTCOME_DEPRECATED = "DEPRECATED";
 
   public static String getFilterBy() {
     return FILTER_BY;

--- a/marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/BaseAction.java
+++ b/marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/BaseAction.java
@@ -3982,6 +3982,13 @@ public class BaseAction extends ActionSupport implements Preparable, SessionAwar
     } catch (Exception e) {
       e.printStackTrace();
     }
+
+    // 10/10/2024 add functionality to avoid no active oicr
+    try {
+      expectedStudies = expectedStudies.stream().filter(o -> o.isActive()).collect(Collectors.toList());
+    } catch (Exception e) {
+      LOG.error(" error in function getexpectedCrpOutcomes - unable to extract inactive oicr");
+    }
     return expectedStudies;
   }
 

--- a/marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/projects/DeliverableAction.java
+++ b/marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/projects/DeliverableAction.java
@@ -1154,9 +1154,11 @@ public class DeliverableAction extends BaseAction {
         if (deliverableTraineesIndicator != null && deliverableTraineesIndicator.getIndicator() != null
           && !deliverableTraineesIndicator.getIndicator().isEmpty()) {
           String indicator = deliverableTraineesIndicator.getIndicator();
-          crpProgramOutcomeIPI =
-            programOutcomes.stream().filter(o -> o.getAcronym() != null && o.getAcronym().equals(indicator))
-              .collect(Collectors.toList()).get(0);
+          crpProgramOutcomeIPI = programOutcomes.stream()
+            .filter(o -> o.getAcronym() != null && o.getAcronym().equals(indicator)
+              && (o.getDescription() == null
+                || !o.getDescription().contains(APConstants.DELIVERABLE_CRP_PROGRAM_OUTCOME_DEPRECATED)))
+            .collect(Collectors.toList()).get(0);
         }
       }
 

--- a/marlo-web/src/main/java/org/cgiar/ccafs/marlo/config/APConstants.java
+++ b/marlo-web/src/main/java/org/cgiar/ccafs/marlo/config/APConstants.java
@@ -865,6 +865,8 @@ public final class APConstants {
   public static final int CLARISA_AVALIABLE_INFO_YEAR = 2018;
 
   public static final String IGNORE_NEWER_YEARS = "ignoreNewer";
+  public static final String DELIVERABLE_CRP_PROGRAM_OUTCOME_DEPRECATED = "DEPRECATED";
+
 
   public static String getFilterBy() {
     return FILTER_BY;


### PR DESCRIPTION
Resolved an issue affecting the proper functioning of IPI 2.3, as well as the inactivity of OICRs in the performance indicators. This fix ensures that all indicators are updated and reflect the correct information.