### PR TITLE
🔧 chore(innovation): Modify query to get deliverables related to the shared clusters

### DIFF
--- a/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/dao/DeliverableInfoDAO.java
+++ b/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/dao/DeliverableInfoDAO.java
@@ -62,6 +62,9 @@ public interface DeliverableInfoDAO {
   public List<DeliverableInfo> getDeliverablesInfoByPhase(Phase phase);
 
 
+  public List<DeliverableInfo> getDeliverablesInfoByPhaseInnovationAndStatus(Phase phase, long innovationId,
+    long statusId);
+
   /**
    * This method gets a list of DeliverableInfo that are active by a given phase, project and status
    * 

--- a/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/dao/mysql/DeliverableInfoMySQLDAO.java
+++ b/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/dao/mysql/DeliverableInfoMySQLDAO.java
@@ -127,6 +127,40 @@ public class DeliverableInfoMySQLDAO extends AbstractMarloDAO<DeliverableInfo, L
   }
 
   @Override
+  public List<DeliverableInfo> getDeliverablesInfoByPhaseInnovationAndStatus(Phase phase, long innovationId,
+    long statusId) {
+
+    StringBuilder query = new StringBuilder();
+    query.append("SELECT DISTINCT  ");
+    query.append("di.id as id ");
+    query.append("FROM ");
+    query.append("deliverables_info AS di ");
+    query.append("INNER JOIN deliverables AS d ON d.id = di.deliverable_id ");
+    query.append("INNER JOIN project_innovation_shared pis ON pis.project_id = d.project_id ");
+    query.append("WHERE d.is_active = 1 AND ");
+    query.append("d.project_id IS NOT NULL AND ");
+    query.append("di.is_active = 1 AND ");
+    query.append("di.`id_phase` =" + phase.getId());
+    query.append(" AND pis.project_innovation_id =" + innovationId);
+    query.append(" AND pis.`id_phase` =" + phase.getId());
+    query.append(" AND pis.is_active =1");
+    query.append(" AND di.status !=" + statusId);
+
+    List<Map<String, Object>> rList = super.findCustomQuery(query.toString());
+    List<DeliverableInfo> deliverableInfos = new ArrayList<>();
+
+    if (rList != null) {
+      for (Map<String, Object> map : rList) {
+        DeliverableInfo deliverableInfo = this.find(Long.parseLong(map.get("id").toString()));
+        deliverableInfos.add(deliverableInfo);
+      }
+    }
+
+    return deliverableInfos;
+  }
+
+
+  @Override
   public List<DeliverableInfo> getDeliverablesInfoByPhaseProjectAndStatus(Phase phase, long projectId, long statusId) {
 
     StringBuilder query = new StringBuilder();
@@ -182,7 +216,6 @@ public class DeliverableInfoMySQLDAO extends AbstractMarloDAO<DeliverableInfo, L
 
     return deliverableInfos;
   }
-
 
   @Override
   public List<DeliverableInfo> getDeliverablesInfoByProjectAndPhaseWithSharedProjects(Phase phase, Project project) {
@@ -264,6 +297,7 @@ public class DeliverableInfoMySQLDAO extends AbstractMarloDAO<DeliverableInfo, L
 
     return false;
   }
+
 
   @Override
   public DeliverableInfo save(DeliverableInfo deliverableInfo) {

--- a/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/dao/mysql/DeliverableMySQLDAO.java
+++ b/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/dao/mysql/DeliverableMySQLDAO.java
@@ -91,10 +91,10 @@ public class DeliverableMySQLDAO extends AbstractMarloDAO<Deliverable, Long> imp
     query.append("SELECT parent_id as parent_id,count(*) as count ");
     query.append("FROM feedback_qa_comments fqc");
     query.append(" WHERE id_phase=" + phase);
-    query.append(" and status_id = 1 ");
+    query.append(" and (status_id = 1 || status_id = 2 || status_id = 5) ");
     query.append(" and field_id in (select id from feedback_qa_commentable_fields fqcf ");
     query.append(" where section_name = 'deliverable') ");
-    query.append(" and reply_id is not null ");
+    query.append(" AND (status_id = 1 OR reply_id IS NOT NULL) ");
     query.append(" group by parent_id ");
 
     List<Map<String, Object>> rList = super.findCustomQuery(query.toString());

--- a/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/dao/mysql/FeedbackQACommentableFieldsMySQLDAO.java
+++ b/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/dao/mysql/FeedbackQACommentableFieldsMySQLDAO.java
@@ -96,10 +96,10 @@ public class FeedbackQACommentableFieldsMySQLDAO extends AbstractMarloDAO<Feedba
     query.append("SELECT parent_id as parent_id,count(*) as count ");
     query.append("FROM feedback_qa_comments fqc");
     query.append(" WHERE id_phase=" + phase);
-    query.append(" and status_id = 1 ");
+    query.append(" and (status_id = 1 || status_id = 2 || status_id = 5)");
     query.append(" and field_id in (select id from feedback_qa_commentable_fields fqcf ");
     query.append(" where section_name = 'study') ");
-    query.append(" and reply_id is not null ");
+    query.append(" AND (status_id = 1 OR reply_id IS NOT NULL) ");
     query.append(" group by parent_id ");
 
     List<Map<String, Object>> rList = super.findCustomQuery(query.toString());

--- a/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/manager/DeliverableInfoManager.java
+++ b/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/manager/DeliverableInfoManager.java
@@ -66,6 +66,8 @@ public interface DeliverableInfoManager {
 
   public List<DeliverableInfo> getDeliverablesInfoByPhase(Phase phase);
 
+  List<DeliverableInfo> getDeliverablesInfoByPhaseInnovationAndStatus(Phase phase, long innovationId, long statusId);
+
   /**
    * This method gets a list of DeliverableInfo that are active by a given phase, project and status
    * 
@@ -80,6 +82,7 @@ public interface DeliverableInfoManager {
    */
   public List<DeliverableInfo> getDeliverablesInfoByProjectAndPhase(Phase phase, Project project);
 
+
   /**
    * This method gets a list of DeliverableInfo that are active by a given phase and project (including shared projects)
    * 
@@ -87,13 +90,13 @@ public interface DeliverableInfoManager {
    */
   List<DeliverableInfo> getDeliverablesInfoByProjectAndPhaseWithSharedProjects(Phase phase, Project project);
 
-
   /**
    * This method gets a list of DeliverableInfo that are active by a given phase and type
    * 
    * @return a list from DeliverableInfo null if no exist records
    */
   public List<DeliverableInfo> getDeliverablesInfoByType(Phase phase, DeliverableType deliverableType);
+
 
   public boolean isDeliverableSubcategoryIncludedWebsite(long deliverableID, Phase phase);
 

--- a/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/manager/impl/DeliverableInfoManagerImpl.java
+++ b/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/manager/impl/DeliverableInfoManagerImpl.java
@@ -100,6 +100,13 @@ public class DeliverableInfoManagerImpl implements DeliverableInfoManager {
   }
 
   @Override
+  public List<DeliverableInfo> getDeliverablesInfoByPhaseInnovationAndStatus(Phase phase, long innovationId,
+    long statusId) {
+    return deliverableInfoDAO.getDeliverablesInfoByPhaseInnovationAndStatus(phase, innovationId, statusId);
+  }
+
+
+  @Override
   public List<DeliverableInfo> getDeliverablesInfoByPhaseProjectAndStatus(Phase phase, long projectId, long statusId) {
     return deliverableInfoDAO.getDeliverablesInfoByPhaseProjectAndStatus(phase, projectId, statusId);
   }
@@ -115,7 +122,6 @@ public class DeliverableInfoManagerImpl implements DeliverableInfoManager {
   public List<DeliverableInfo> getDeliverablesInfoByProjectAndPhaseWithSharedProjects(Phase phase, Project project) {
     return deliverableInfoDAO.getDeliverablesInfoByProjectAndPhaseWithSharedProjects(phase, project);
   }
-
 
   @Override
   public List<DeliverableInfo> getDeliverablesInfoByType(Phase phase, DeliverableType deliverableType) {

--- a/marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/projects/ProjectExpectedStudiesListAction.java
+++ b/marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/projects/ProjectExpectedStudiesListAction.java
@@ -223,46 +223,47 @@ public class ProjectExpectedStudiesListAction extends BaseAction {
       List<FeedbackQACommentableFields> commentableFields = new ArrayList<>();
 
       // get the commentable fields by sectionName
-      if (feedbackQACommentableFieldsManager.findAll() != null) {
-        commentableFields = feedbackQACommentableFieldsManager.findAll().stream()
-          .filter(f -> f != null && f.getSectionName().equals("study")).collect(Collectors.toList());
-      }
+      commentableFields = feedbackQACommentableFieldsManager.findBySectionName("study");
+
       if (projectStudies != null && !projectStudies.isEmpty() && commentableFields != null
         && !commentableFields.isEmpty()) {
-
 
         // Set the comment status in each project outcome
         for (ProjectExpectedStudy study : projectStudies) {
           int answeredComments = 0, totalComments = 0;
           try {
 
-
             for (FeedbackQACommentableFields commentableField : commentableFields) {
               if (commentableField != null && commentableField.getId() != null) {
 
                 if (study != null && study.getId() != null && commentableField != null
                   && commentableField.getId() != null) {
-                  List<FeedbackQAComment> comments = commentManager.findAll().stream()
-                    .filter(f -> f != null && f.getParentId() == study.getId()
+
+                  List<FeedbackQAComment> comments = commentManager
+                    .getFeedbackQACommentsByPhaseAndParentId(this.getActualPhase().getId(), study.getId()).stream()
+                    .filter(f -> f != null
 
                       && (f.getFeedbackStatus() != null && f.getFeedbackStatus().getId() != null && (!f
                         .getFeedbackStatus().getId().equals(Long.parseLong(FeedbackStatusEnum.Dismissed.getStatusId()))
                       // &&
                       // !f.getFeedbackStatus().getId().equals(Long.parseLong(FeedbackStatusEnum.Draft.getStatusId()))
-                      ))
-
-                      && f.getField() != null && f.getField().getId().equals(commentableField.getId()))
+                      )) && f.getField() != null && f.getField().getId().equals(commentableField.getId()))
                     .collect(Collectors.toList());
+
                   if (comments != null && !comments.isEmpty()) {
                     totalComments += comments.size();
-                    comments = comments.stream()
-                      .filter(f -> f != null && ((f.getFeedbackStatus() != null && f.getFeedbackStatus().getId()
-                        .equals(Long.parseLong(FeedbackStatusEnum.Agreed.getStatusId())))
-                        || (f.getFeedbackStatus() != null && f.getReply() != null)))
-                      .collect(Collectors.toList());
-                    if (comments != null) {
-                      answeredComments += comments.size();
-                    }
+                    List<FeedbackQAComment> filteredComments = comments.stream().filter(f -> {
+                      Long statusId = f.getFeedbackStatus() != null ? f.getFeedbackStatus().getId() : null;
+                      boolean isDisagreedOrClarificationNeeded =
+                        statusId != null && (statusId.equals(Long.valueOf(FeedbackStatusEnum.Disagreed.getStatusId()))
+                          || statusId.equals(Long.valueOf(FeedbackStatusEnum.ClarificatioNeeded.getStatusId())));
+                      boolean isAgreed =
+                        statusId != null && statusId.equals(Long.valueOf(FeedbackStatusEnum.Agreed.getStatusId()));
+
+                      return (isDisagreedOrClarificationNeeded && f.getReply() != null) || isAgreed;
+                    }).collect(Collectors.toList());
+
+                    answeredComments += filteredComments.size();
                   }
                 }
               }

--- a/marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/projects/ProjectInnovationAction.java
+++ b/marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/projects/ProjectInnovationAction.java
@@ -1754,48 +1754,60 @@ public class ProjectInnovationAction extends BaseAction {
       }
 
       List<Project> projectSharedList = new ArrayList<>();
-      if (innovation.getSharedInnovations() != null && !innovation.getSharedInnovations().isEmpty()) {
-        for (ProjectInnovationShared sharedInnovation : innovation.getSharedInnovations()) {
-          if (sharedInnovation != null && sharedInnovation.getProject() != null
-            && sharedInnovation.getProject().getId() != null) {
-            projectSharedList.add(sharedInnovation.getProject());
-          }
-        }
+      try {
+        if (innovation.getSharedInnovations() != null && !innovation.getSharedInnovations().isEmpty()) {
+          /*
+           * for (ProjectInnovationShared sharedInnovation :
+           * innovation.getSharedInnovations()) {
+           * if (sharedInnovation != null && sharedInnovation.getProject() != null
+           * && sharedInnovation.getProject().getId() != null) {
+           * projectSharedList.add(sharedInnovation.getProject());
+           * }
+           * }
+           */
 
-        Set<DeliverableInfo> deliverableInfosShared = phase.getDeliverableInfos();
-        // Get deliverable list for shared innovations projects
-        if (projectSharedList != null && !projectSharedList.isEmpty()) {
-          for (Project projectInnovationShared : projectSharedList) {
-            if (phase != null && deliverableInfosShared != null && projectInnovationShared != null
-              && !deliverableInfosShared.isEmpty()) {
-              /*
-               * 16/12/2024 cgamboa the query was reduced
-               * List<DeliverableInfo> infos = phase.getDeliverableInfos().stream()
-               * .filter(c -> c != null && c.getDeliverable() != null && c.getDeliverable().getProject() != null
-               * && c.getDeliverable().getProject().equals(projectInnovationShared) && c.getDeliverable().isActive()
-               * && c.getDeliverable().getDeliverableInfo(this.getActualPhase()) != null
-               * && c.getDeliverable().getDeliverableInfo(this.getActualPhase()).getStatus() != null
-               * && c.getDeliverable().getDeliverableInfo(this.getActualPhase()).getStatus() != 5)
-               * .collect(Collectors.toList());
-               */
-              List<DeliverableInfo> infos = new ArrayList<>();
-              try {
+          // Set<DeliverableInfo> deliverableInfosShared = phase.getDeliverableInfos();
+          // Get deliverable list for shared innovations projects
+          // if (projectSharedList != null && !projectSharedList.isEmpty()) {
+          /*
+           * for (Project projectInnovationShared : projectSharedList) {
+           * if (phase != null && deliverableInfosShared != null &&
+           * projectInnovationShared != null
+           * && !deliverableInfosShared.isEmpty()) {
+           * List<DeliverableInfo> infos = phase.getDeliverableInfos().stream()
+           * .filter(c -> c != null && c.getDeliverable() != null &&
+           * c.getDeliverable().getProject() != null
+           * && c.getDeliverable().getProject().equals(projectInnovationShared) &&
+           * c.getDeliverable().isActive()
+           * && c.getDeliverable().getDeliverableInfo(this.getActualPhase()) != null
+           * && c.getDeliverable().getDeliverableInfo(this.getActualPhase()).getStatus()
+           * != null
+           * && c.getDeliverable().getDeliverableInfo(this.getActualPhase()).getStatus()
+           * != 5)
+           * .collect(Collectors.toList());
+           * counting = infos.size() + counting;
+           * for (DeliverableInfo deliverableInfo : infos) {
+           * Deliverable deliverable = deliverableInfo.getDeliverable();
+           * deliverable.setDeliverableInfo(deliverableInfo);
+           * deliverable.setTagTitle(deliverable.getComposedName());
+           * deliverableList.add(deliverable);
+           * }
+           * }
+           * }
+           */
 
-                infos = this.deliverableInfoManager
-                  .getDeliverablesInfoByPhaseProjectAndStatus(phase, projectInnovationShared.getId(), 5L).stream()
-                  .filter(c -> c != null).collect(Collectors.toList());
-              } catch (Exception e) {
-                logger.error(" unable to get deliverable info " + e.getMessage());
-              }
-              for (DeliverableInfo deliverableInfo : infos) {
-                Deliverable deliverable = deliverableInfo.getDeliverable();
-                deliverable.setDeliverableInfo(deliverableInfo);
-                deliverable.setTagTitle(deliverable.getComposedName());
-                deliverableList.add(deliverable);
-              }
-            }
+          List<DeliverableInfo> infos =
+            this.deliverableInfoManager.getDeliverablesInfoByPhaseInnovationAndStatus(phase, innovation.getId(), 5L);
+          for (DeliverableInfo deliverableInfo : infos) {
+            Deliverable deliverable = deliverableInfo.getDeliverable();
+            deliverable.setDeliverableInfo(deliverableInfo);
+            deliverable.setTagTitle(deliverable.getComposedName());
+            deliverableList.add(deliverable);
           }
+          // }
         }
+      } catch (Exception e) {
+        logger.error("unable to get shared deliverables", e);
       }
 
       /**

--- a/marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/projects/ProjectInnovationListAction.java
+++ b/marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/projects/ProjectInnovationListAction.java
@@ -349,13 +349,10 @@ public class ProjectInnovationListAction extends BaseAction {
       List<FeedbackQACommentableFields> commentableFields = new ArrayList<>();
 
       // get the commentable fields by sectionName
-      if (feedbackQACommentableFieldsManager.findAll() != null) {
-        commentableFields = feedbackQACommentableFieldsManager.findAll().stream()
-          .filter(f -> f != null && f.getSectionName().equals("innovation")).collect(Collectors.toList());
-      }
+      commentableFields = feedbackQACommentableFieldsManager.findBySectionName("innovation");
+
       if (projectInnovations != null && !projectInnovations.isEmpty() && commentableFields != null
         && !commentableFields.isEmpty()) {
-
 
         // Set the comment status in each project outcome
 
@@ -363,33 +360,37 @@ public class ProjectInnovationListAction extends BaseAction {
           int answeredComments = 0, totalComments = 0;
           try {
 
-
             for (FeedbackQACommentableFields commentableField : commentableFields) {
               if (commentableField != null && commentableField.getId() != null) {
 
                 if (study != null && study.getId() != null && commentableField != null
                   && commentableField.getId() != null) {
-                  List<FeedbackQAComment> comments = commentManager.findAll().stream()
-                    .filter(f -> f != null && f.getParentId() == study.getId()
+
+                  List<FeedbackQAComment> comments = commentManager
+                    .getFeedbackQACommentsByPhaseAndParentId(this.getActualPhase().getId(), study.getId()).stream()
+                    .filter(f -> f != null
 
                       && (f.getFeedbackStatus() != null && f.getFeedbackStatus().getId() != null && (!f
                         .getFeedbackStatus().getId().equals(Long.parseLong(FeedbackStatusEnum.Dismissed.getStatusId()))
                       // &&
                       // !f.getFeedbackStatus().getId().equals(Long.parseLong(FeedbackStatusEnum.Draft.getStatusId()))
-                      ))
-
-                      && f.getField() != null && f.getField().getId().equals(commentableField.getId()))
+                      )) && f.getField() != null && f.getField().getId().equals(commentableField.getId()))
                     .collect(Collectors.toList());
+
                   if (comments != null && !comments.isEmpty()) {
                     totalComments += comments.size();
-                    comments = comments.stream()
-                      .filter(f -> f != null && ((f.getFeedbackStatus() != null && f.getFeedbackStatus().getId()
-                        .equals(Long.parseLong(FeedbackStatusEnum.Agreed.getStatusId())))
-                        || (f.getFeedbackStatus() != null && f.getReply() != null)))
-                      .collect(Collectors.toList());
-                    if (comments != null) {
-                      answeredComments += comments.size();
-                    }
+                    List<FeedbackQAComment> filteredComments = comments.stream().filter(f -> {
+                      Long statusId = f.getFeedbackStatus() != null ? f.getFeedbackStatus().getId() : null;
+                      boolean isDisagreedOrClarificationNeeded =
+                        statusId != null && (statusId.equals(Long.valueOf(FeedbackStatusEnum.Disagreed.getStatusId()))
+                          || statusId.equals(Long.valueOf(FeedbackStatusEnum.ClarificatioNeeded.getStatusId())));
+                      boolean isAgreed =
+                        statusId != null && statusId.equals(Long.valueOf(FeedbackStatusEnum.Agreed.getStatusId()));
+
+                      return (isDisagreedOrClarificationNeeded && f.getReply() != null) || isAgreed;
+                    }).collect(Collectors.toList());
+
+                    answeredComments += filteredComments.size();
                   }
                 }
               }

--- a/marlo-web/src/main/webapp/WEB-INF/global/macros/innovationTemplates.ftl
+++ b/marlo-web/src/main/webapp/WEB-INF/global/macros/innovationTemplates.ftl
@@ -352,7 +352,7 @@
                 [#-- Element item Template --]
                 <div style="display:none">
                   [@actorsMacro name="innovation.actors" element={} index=-1 template=true /]
-                  [@organizationsMacro name="innovation.allianceOrganizations" element={} index=-1 template=true /]
+                  [@organizationsMacro name="innovation.allianceOrganizations" element={'id':''?string} index=-1 template=true /]
                 </div>
 
               </div>
@@ -800,7 +800,7 @@
   [#local customName = "${template?string('_TEMPLATE_', '')}${name}[${index}]"]
   <div id="organizationsInnovation-${(template?string('template', ''))}" class="organizationsInnovation form-group grayBlueBox ${class}">
     [#-- Hidden not saved - id --]
-    [@customForm.input name="${customName}.id" className="indexTag" value=((element.id)?string)!"" editable=false display=false /]
+    [@customForm.input name="${customName}.id" className="indexTag" value=((element.id)?string) editable=false display=false /]
     [#-- "Dropdown Organizations - Type 
     <div class="col-md-12">
       [@customForm.select name="${customName}.institutionType.id" showTitle=false  i18nkey="projectInnovations.organizations" listName="institutionTypeList" keyFieldName="id" displayFieldName="name" required=false editable=true /]

--- a/marlo-web/src/main/webapp/WEB-INF/global/pages/header.ftl
+++ b/marlo-web/src/main/webapp/WEB-INF/global/pages/header.ftl
@@ -93,6 +93,22 @@
       gtag('config', '${googleAnalyticsID}');
     </script>
     <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+
+    [#-- CLARITY --]
+    [#if config.production]
+      [#assign clarityID = "q68ywho43z"]
+    [#else]
+      [#assign clarityID = "q68vmhjr80"]
+    [/#if]
+
+    <script type="text/javascript">
+      (function(c,l,a,r,i,t,y){
+          c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+          t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+          y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+      })(window, document, "clarity", "script", "${clarityID}");
+    </script>
+
   </head>
   <body class="mode-${editable?string('editable', 'readOnly')}">
     [#if !(avoidHeader!false)]


### PR DESCRIPTION
This update refactors the existing query responsible for fetching deliverables related to shared clusters. Previously, the system was processing the data in memory, leading to performance issues. The new query aims to fetch all relevant information directly from the lists, reducing memory consumption and improving overall system efficiency. This change should help minimize delays and optimize data retrieval for shared clusters.