### PR TITLE
se realiza ajuste para pages Deliverables, OICRs, Innovations

### DIFF
--- a/marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/projects/DeliverableListAction.java
+++ b/marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/projects/DeliverableListAction.java
@@ -115,6 +115,7 @@ public class DeliverableListAction extends BaseAction {
     this.projectDeliverableSharedManager = projectDeliverableSharedManager;
     this.feedbackQACommentableFieldsManager = feedbackQACommentableFieldsManager;
     this.commentManager = commentManager;
+    this.deliverables = new ArrayList<>();
   }
 
   @Override
@@ -1264,9 +1265,11 @@ public class DeliverableListAction extends BaseAction {
     this.deliverableID = deliverableID;
   }
 
-  public void setDeliverables(List<Deliverable> deliverables) {
-    this.deliverables = deliverables;
-  }
+  // Removed setter for 'deliverables' to avoid Spring autowiring a bean named 'deliverables'
+  // into this action (caused a type conversion error when a Spring bean named
+  // 'deliverables' of a different type was present in the context). If a setter
+  // is required later for incoming parameters, add a differently named setter
+  // (e.g. setDeliverableList) to avoid name collision with Spring beans.
 
   public void setDeliverablesType(List<DeliverableType> deliverablesType) {
     this.deliverablesType = deliverablesType;

--- a/marlo-web/src/main/webapp/WEB-INF/global/macros/utils.ftl
+++ b/marlo-web/src/main/webapp/WEB-INF/global/macros/utils.ftl
@@ -103,7 +103,16 @@
 [#macro prefilledTag]<i style="opacity:0.5">[@s.text name="global.prefilledWhenAvailable"/]</i>[/#macro]
 
 [#macro tableText value nobr=false emptyText="global.notDefined"]
-  [#if (value?trim?has_content)!false] <span style="${nobr?string('white-space: nowrap;','word-wrap: break-word;')}"> ${value?trim} </span> [#else]<i style="font-weight: normal;opacity:0.8;"><nobr>[@s.text name="${emptyText}"/]</nobr></i>[/#if]
+  [#assign valueStr = (value?is_markup_output)?then(value?markup_string, value!)]
+  [#if (valueStr?trim?has_content)!false]
+    <span style="${nobr?string('white-space: nowrap;','word-wrap: break-word;')}">
+      ${valueStr?trim?no_esc}
+    </span>
+  [#else]
+    <i style="font-weight: normal; opacity: 0.8;">
+      <nobr>[@s.text name=emptyText /]</nobr>
+    </i>
+  [/#if]
 [/#macro]
 
 [#macro tableList list displayFieldName="title" showEmpty=true nobr=false emptyText="global.notDefined" class="" scroll=false]


### PR DESCRIPTION
This pull request addresses a Spring bean autowiring issue in the `DeliverableListAction` class and improves the handling of markup output in the Freemarker `tableText` macro. The most important changes are grouped below:

Spring bean autowiring fix:

* Removed the `setDeliverables` setter from `DeliverableListAction` to prevent Spring from autowiring a bean named `deliverables`, which previously caused type conversion errors when a bean of a different type existed in the context. Added comments explaining the issue and suggesting an alternative setter name if needed in the future.
* Initialized the `deliverables` field to an empty `ArrayList` in the constructor to ensure it's always defined.

Freemarker macro improvement:

* Updated the `tableText` macro in `utils.ftl` to properly handle values that are markup output, ensuring correct rendering and escaping in the UI.