### PR TITLE
Refactor: update MARLO Docs and global units

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,3 +209,24 @@ Scripts in `scripts/` run MARLO locally (build, update properties, start server)
 - Otherwise, use the Java 8 run script in `scripts/`:
   - macOS/Linux: `scripts/run-marlo-java8.sh`
   - Windows: `scripts/run-marlo-java8.bat` (if provided; otherwise use `.sh` in Git Bash)
+
+## Operational Context Documentation
+Use these documents as the primary operational context for semi-autonomous work in critical modules:
+
+### Frontend & Composition
+- `reports/ai-context/frontend-composition-map.md`
+
+### Save & Validation
+- `reports/ai-context/save-validation-matrix.md`
+
+### Persistence & Replication
+- `reports/ai-context/persistence-replication-managerimpl.md`
+
+### Routing & Interceptors
+- `reports/ai-context/struts-critical-routing-catalog.md`
+- `reports/ai-context/interceptor-validator-playbook.md`
+
+### Scope Guardrails
+- Internal MARLO flows should prioritize Struts `.do` actions and existing FTL composition.
+- `struts-json` usage is punctual and should only be extended when there is an existing JSON pattern in the same module.
+- `/api/*` (Spring MVC) is out of scope for internal flow implementation and remains reference-only in this context pack.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,103 @@ Use the GPL header for new Java files (as specified in the project setup guide):
 - Follow the existing naming pattern in that directory.
 - Naming format (examples in repo): `V<major>_<minor>_<patch>_<YYYYMMDD>_<HHMM>__<Description>.sql`
 
+## Specificity Implementation Guide
+Use this workflow when creating a new specificity (feature flag based on `parameters` + `custom_parameters`).
+
+### 1. Create migration for `parameters`
+- Create one migration in `marlo-web/src/main/resources/database/migrations/`.
+- Follow the same style used by existing specificity migrations (direct `INSERT ... VALUES`).
+- Add one row per `global_unit_type_id` used by CRP/Platform/Center (`1`, `3`, `4`).
+- Use `category = '2'` (Specificities) and `format = '1'` (boolean-like).
+
+Template:
+
+```sql
+INSERT INTO parameters (global_unit_type_id, `key`, `description`, `format`, default_value, category)
+VALUES ( '1', '<specificity_key>', '<Specificity description>', '1', 'false', '2');
+
+INSERT INTO parameters (global_unit_type_id, `key`, `description`, `format`, default_value, category)
+VALUES ( '3', '<specificity_key>', '<Specificity description>', '1', 'false', '2');
+
+INSERT INTO parameters (global_unit_type_id, `key`, `description`, `format`, default_value, category)
+VALUES ( '4', '<specificity_key>', '<Specificity description>', '1', 'false', '2');
+```
+
+### 2. Create/Update migration for `custom_parameters` values
+- If the specificity must be enabled for a specific Global Unit, add inserts/updates in `custom_parameters`.
+- Use `value = 'true'` or `value = 'false'` depending on rollout.
+- Link using `parameter_id` from `parameters.key`.
+
+Template:
+
+```sql
+INSERT INTO custom_parameters (`parameter_id`, `global_unit_id`, `value`, `created_by`, `is_active`, `active_since`, `modified_by`, `modification_justification`)
+VALUES (
+  (SELECT id FROM parameters WHERE `key` = '<specificity_key>' AND global_unit_type_id = 1),
+  <global_unit_id>,
+  'true',
+  '3',
+  '1',
+  CURRENT_TIMESTAMP,
+  '3',
+  'Enable <specificity_key>'
+);
+```
+
+### 3. Add constants in APConstants
+- Add the new key in both constants files:
+  - `marlo-data/src/main/java/org/cgiar/ccafs/marlo/config/APConstants.java`
+  - `marlo-web/src/main/java/org/cgiar/ccafs/marlo/config/APConstants.java`
+- Constant name should be uppercase snake case and value must match `parameters.key` exactly.
+
+Template:
+
+```java
+public static final String <SPECIFICITY_CONSTANT_NAME> = "<specificity_key>";
+```
+
+### 4. Backend usage (Java)
+- Prefer using APConstants constant instead of hardcoded strings.
+- Typical usage is through `BaseAction.hasSpecificities(...)`.
+
+Example:
+
+```java
+if (this.hasSpecificities(APConstants.<SPECIFICITY_CONSTANT_NAME>)) {
+  // feature enabled behavior
+} else {
+  // fallback behavior
+}
+```
+
+### 5. Frontend usage (FTL/JSP/JS)
+- In FTL views, use `action.hasSpecificities('<specificity_key>')` to toggle sections.
+- Keep behavior explicit with `[#if] ... [/#if]` blocks.
+
+Example:
+
+```ftl
+[#if action.hasSpecificities('<specificity_key>')]
+  [#-- enabled content --]
+[/#if]
+```
+
+or for hide-on-true behavior:
+
+```ftl
+[#if !action.hasSpecificities('<specificity_key>')]
+  [#-- default visible content --]
+[/#if]
+```
+
+### 6. Validation checklist
+- Migration file name follows `V<major>_<minor>_<patch>_<YYYYMMDD>_<HHMM>__<Description>.sql`.
+- `parameters.key` and APConstants value are identical.
+- Constant added in both APConstants files.
+- Backend uses APConstants (no hardcoded key literals in Java).
+- Frontend condition matches expected behavior (`show when true` or `hide when true`).
+- If rollout is required, corresponding `custom_parameters` values are created.
+
 ## File Organization (Quick Reference)
 - Actions: `marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/`
 - Base Action: `marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/BaseAction.java`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# Claude / AI Agent Guide for MARLO
+
+This file is the entry point for Claude Code (and any AI assistant) working on MARLO. It is intentionally short. It points to the documents that hold the real content.
+
+> **Constitutional baseline:** the repository follows a Spec-Driven Development (SDD) methodology rooted in the documents listed below. New work MUST be aligned with this baseline. Deviations require an explicit, justified Decision Log entry inside the relevant module spec.
+
+---
+
+## Read first, in this order
+
+1. **[AGENTS.md](./AGENTS.md)** — the operational ground truth for this repo: language, file headers, code style, Checkstyle config, migration naming, specificity workflow, file organization, run scripts. *Never skip this file.*
+2. **[docs/prd.md](./docs/prd.md)** — what MARLO is, who it serves, what success looks like. Use it to anchor product decisions.
+3. **[docs/system-design/design.md](./docs/system-design/design.md)** — UI / UX system blueprint: information architecture, screen inventory, navigation, layout patterns, component inventory, accessibility commitments.
+4. **[docs/detailed-design/detailed-design.md](./docs/detailed-design/detailed-design.md)** — technical blueprint: modules, data model, API surface, save pipeline, security model, observability, testing strategy, ADR snapshots.
+5. **[docs/specs/general-setup/](./docs/specs/general-setup/)** — methodology templates for module specs (`requirements.md`, `design.md`, `task.md`).
+6. **[reports/ai-context/](./reports/ai-context/)** — operational runbooks for the most touched flows (frontend composition, save validation matrix, persistence replication, struts routing, interceptor playbook). Treat these as authoritative companions when modifying critical sections.
+7. **[EXPANDABLE_BLOCKS_AGENT_INSTRUCTIONS.md](./EXPANDABLE_BLOCKS_AGENT_INSTRUCTIONS.md)** — debugging runbook for accordion-style list UIs.
+
+---
+
+## When to consult which document
+
+| Task | Primary document(s) |
+|---|---|
+| Understand product scope, personas, success metrics | `docs/prd.md` |
+| Add a UI screen, component, or navigation change | `docs/system-design/design.md` + `reports/ai-context/frontend-composition-map.md` |
+| Touch a save path, validator, interceptor stack, or REST endpoint | `docs/detailed-design/detailed-design.md` + `reports/ai-context/save-validation-matrix.md` + `reports/ai-context/interceptor-validator-playbook.md` + `reports/ai-context/struts-critical-routing-catalog.md` |
+| Touch a `ManagerImpl` save / delete chain | `docs/detailed-design/detailed-design.md` §3, §5 + `reports/ai-context/persistence-replication-managerimpl.md` |
+| Add a feature flag conditional on Global Unit | `AGENTS.md` "Specificity Implementation Guide" |
+| Add a database column, table, index, or migration | `AGENTS.md` "Database Migrations" + `docs/detailed-design/detailed-design.md` §3 |
+| Add or change i18n strings | `AGENTS.md` "File Organization" + `marlo-web/src/main/resources/global.properties` (and `custom/*.properties` per program) |
+| Build or update a module spec | `docs/specs/general-setup/requirements.md` + `design.md` + `task.md` |
+| Onboard a new spec area | Pick the right taxonomy folder under `docs/specs/`: `domain/`, `enhancement/`, `bugfix/`, or `epic/` |
+
+---
+
+## Spec taxonomy under `docs/specs/`
+
+- `docs/specs/general-setup/` — methodology templates (read-only for individual specs; update only as a constitutional change).
+- `docs/specs/domain/<module>/` — module-level specs aligned with MARLO domain areas (e.g., `domain/projects/`, `domain/deliverables/`, `domain/innovations/`, `domain/oicrs/`, `domain/powb/`, `domain/annual-report/`, `domain/qa/`, `domain/admin/`, `domain/auth/`, `domain/bi/`, `domain/ai-services/`).
+- `docs/specs/enhancement/<feature>/` — cross-cutting enhancements that don't belong to a single domain (e.g., `enhancement/dark-mode/`, `enhancement/design-tokens/`, `enhancement/a11y-automation/`).
+- `docs/specs/bugfix/<slug>/` — structured bug-driven specs that need explicit traceability beyond a normal commit.
+- `docs/specs/epic/<name>/` — multi-spec initiatives (e.g., `epic/java-17-cutover/`, `epic/tenant-onboarding/`, `epic/legacy-modules-retirement/`).
+
+Each spec folder MUST contain three files: `requirements.md`, `design.md`, `task.md`, all following the templates under `docs/specs/general-setup/`.
+
+---
+
+## Hard rules (do not violate without explicit user approval)
+
+1. **Phased data is forward-only.** Saves replicate to current and future phases; past phases are immutable.
+2. **Save pipeline pattern is non-negotiable** for critical sections: `Action.validate()` guarded by `if (save)` → `Validator` → manager save chain.
+3. **Spring MVC owns `/api/*`.** Struts is excluded from this prefix. Do not introduce new `*.json` Struts paths unless an existing pattern in the same module already requires it.
+4. **Specificities go through `parameters` + `custom_parameters`** with constants in *both* `APConstants.java` files (in `marlo-data/` and `marlo-web/`). The constant value MUST equal the `parameters.key`.
+5. **All schema changes ship as Flyway migrations** under `marlo-web/src/main/resources/database/migrations/` with the `V<major>_<minor>_<patch>_<YYYYMMDD>_<HHMM>__<Description>.sql` naming.
+6. **GPL header on every new Java file** (template in `AGENTS.md`).
+7. **Code style:** 2-space indent, 120 char line limit, braces on same line, mandatory blocks for `if/while/for/do`, max file length 3500 lines. Checkstyle (`mvn checkstyle:check`) is a gate.
+8. **English only** in code, identifiers, and inline comments. User-facing strings MUST be i18n-keyed.
+9. **Branching:** never commit directly to `AICCRA`. Feature branches start from `aiccra-staging` and merge back into it. `aiccra-dev` is unstable and used only for integration experiments.
+10. **Run scripts:** branches containing `java17` / `java_17` use `scripts/run-marlo-java17.sh`; otherwise `scripts/run-marlo-java8.sh`.
+11. **Dependency floors (post-Jan 2026 SETI baseline) MUST NOT be downgraded:** Struts2 ≥ 6.4.0, Tomcat Catalina ≥ 9.0.96, Spring Framework ≥ 5.3.39, Jackson ≥ 2.17.x, HikariCP ≥ 5.x, Springdoc OpenAPI (replaces Springfox/Swagger 2.9.2), Groovy ≥ 2.4.21.
+12. **Do not commit credential files.** `marlo-${profile}.properties` is gitignored; bootstrap from `marlo-test.properties`.
+
+---
+
+## How to start a new piece of work
+
+1. Read this file, `AGENTS.md`, and the relevant ai-context docs.
+2. Locate or create the spec folder under `docs/specs/...`.
+3. Draft `requirements.md` (use `docs/specs/general-setup/requirements.md` as the template).
+4. Draft `design.md` (use `docs/specs/general-setup/design.md` as the template).
+5. Draft `task.md` (use `docs/specs/general-setup/task.md` as the template).
+6. Have the spec reviewed before implementation begins.
+7. Implement against the task plan; keep `task.md` up to date with verification notes.
+8. Update relevant `reports/ai-context/*.md` files when the change alters routing, validation, replication, or composition contracts.
+
+---
+
+## Constitutional change process
+
+A change to any of these documents is a constitutional event:
+
+- `docs/prd.md`
+- `docs/system-design/design.md`
+- `docs/detailed-design/detailed-design.md`
+- `docs/specs/general-setup/*`
+- `AGENTS.md`
+- This file (`CLAUDE.md`)
+
+Constitutional changes MUST:
+
+1. Be proposed via an `epic` spec under `docs/specs/epic/<name>/`.
+2. Include an explicit Decision Log entry in `requirements.md`.
+3. Be reviewed by the IBD team lead and at least one of: PMU lead, QA lead, Tech lead.
+4. Land in `aiccra-staging` only after approval; production promotion follows the standard release pipeline.
+
+---
+
+## Contact
+
+- IBD Team — Alliance of Bioversity International and CIAT.
+- MARLO Support: `Marlosupport@cgiar.org`.
+- GitHub: `https://github.com/CCAFS/MARLO`.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,261 @@
-## MARLO [![GitHub license](https://img.shields.io/badge/license-AGPL-blue.svg)](https://raw.githubusercontent.com/CCAFS/MARLO/master/LICENSE)  [![GitHub issues](https://img.shields.io/github/issues/CCAFS/MARLO.svg)](https://github.com/CCAFS/MARLO/issues)  
-(Managing Agricultural Research for Learning and Outcomes)
+# MARLO
 
-MARLO is a user-friendly, online management platform for CGIAR Research Programs, such functionality includes:
-* Active directory login
-* Multiple CRPs
-* Pre-Planning (Impact Pathway definition)
-* Projects (Planning/Reporting)
-* Synthesis 
-* Summaries
+**Managing Agricultural Research for Learning and Outcomes**
 
-[Go to Wiki](https://github.com/CCAFS/MARLO/wiki)
+[![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue.svg)](./LICENSE)
+[![GitHub issues](https://img.shields.io/github/issues/CCAFS/MARLO.svg)](https://github.com/CCAFS/MARLO/issues)
 
+MARLO is an open-source, web-based research management platform that supports the full Planning, Monitoring, Reporting, and Learning (PMRL) cycle of complex multi-country, multi-stakeholder research programs. Originally built within the CGIAR system and now actively maintained by the IBD Team at the Alliance of Bioversity International and CIAT, MARLO is the system of record for annual planning, deliverables, innovations, outcome impact case reports (OICRs), and indicator contributions across one or more research programs.
+
+This repository hosts the **AICCRA** production line of MARLO. The platform has been deployed at scale on programs such as **CCAFS** (2017+) and **AICCRA** (2021–present), where it powered planning and reporting for 11 clusters across multiple African countries and supported the generation of 1,440+ knowledge products with 95%+ open-access compliance and 92%+ quality ratings.
+
+---
+
+## Why MARLO
+
+MARLO replaces the spreadsheets, email chains, and fragmented reporting that complex research programs typically rely on. It provides:
+
+- A single, phase-aware system of record (POWB / UpKeep / Annual Report).
+- Embedded quality assurance with structured reviewer feedback.
+- Built-in Open Access and FAIR compliance tracking.
+- A multi-tenant model for running multiple Programs / Platforms / Centers on one platform.
+- An analytics path through Microsoft Fabric (Bronze / Silver / Gold) and Power BI.
+- AI-augmented services (Text Mining, Reports Generator, Chatbot) that consume MARLO data without bypassing its governance.
+- Audit-friendly forward-only phase replication: past data is immutable, future data inherits planned changes.
+
+For the full product framing, see [`docs/prd.md`](./docs/prd.md).
+
+---
+
+## Core capabilities
+
+- **Annual Work Plan and Budget (AWPB)** — planning per cluster / project.
+- **Progress Monitoring** — continuous, intra-year tracking.
+- **Annual Reporting (AR)** — narrative + structured indicators + cluster synthesis.
+- **Deliverables Management** — full lifecycle, Open Access, FAIR principles.
+- **Innovation Tracking** — Scaling Readiness 0–9, typology, geographic tagging.
+- **Outcome Impact Case Reports (OICRs)** — structured documentation with maturity classification.
+- **Quality Assurance** — structured feedback workflows between reviewers and implementers.
+- **Funding & Partner Management** — CLARISA-integrated.
+- **Impact Pathway Management** — SLOs, IDOs, cross-cutting issues.
+- **Business Intelligence** — embedded Power BI dashboards (results, QA, completeness, public).
+- **AI Services** — text mining, narrative generation, conversational data exploration (AWS Bedrock + Claude + Titan + OpenSearch).
+- **Multi-tenant Administration** — onboard a new Program / Platform / Center with its own roles, phases, partners, locations, and per-program feature flags ("specificities").
+
+---
+
+## Technology stack
+
+| Concern | Technology |
+|---|---|
+| Language | Java (8 and 17 branches coexist) |
+| Web framework (internal flows) | Apache Struts 2 (≥ 6.4.0) |
+| Web framework (REST API) | Spring MVC under `/api/*` (Spring ≥ 5.3.39) |
+| ORM | Hibernate 5.4.x |
+| Database | MySQL (AWS RDS in production) |
+| Connection pool | HikariCP (≥ 5.x) |
+| Servlet container | Apache Tomcat 9 (≥ 9.0.96) |
+| Templating | FreeMarker (`.ftl`) |
+| Build | Apache Maven (multi-module) + Grunt (frontend assets) |
+| DB migrations | Flyway |
+| Security | Apache Shiro 1.13.0 + CGIAR Active Directory |
+| Dependency injection | Google Guice + Spring |
+| API docs | Springdoc OpenAPI |
+| Frontend assets | Bower (jQuery, Bootstrap, DataTables, Chosen, Pickadate, Trumbowyg, Cytoscape, Font Awesome, etc.) |
+| Real-time notifications | Pusher |
+| Reporting / export | Pentaho Reporting, iText, Apache POI |
+| Analytics | Microsoft Fabric (Lakehouse, Bronze/Silver/Gold) + Power BI |
+| AI | AWS Bedrock (Claude, Titan), Amazon OpenSearch, AWS Lambda |
+| CI/CD | GitHub Actions → Jenkins; SonarCloud; Snyk |
+
+Dependency floors (post-January 2026 SETI security modernization) MUST NOT be downgraded — see [`docs/detailed-design/detailed-design.md`](./docs/detailed-design/detailed-design.md) §8.5.
+
+---
+
+## Repository layout
+
+```
+MARLO/
+├── marlo-parent/        Root Maven aggregator: dependency versions + plugin config (no executable code)
+├── marlo-utils/         Pure utility classes (dates, strings, Excel/CSV/PDF, JSON helpers)
+├── marlo-core/          Cross-cutting configuration: Shiro, Hibernate session factory, DB config
+├── marlo-data/          Domain layer: 540+ JPA entities, Manager/ManagerImpl, DAO/MySQLDAO, audit listeners
+├── marlo-web/           Web tier: Struts actions, Spring REST controllers, FTL templates, validators,
+│                        interceptors, JS/CSS, SQL migrations
+├── docs/                Constitutional documents (PRD, system design, detailed design, spec templates)
+├── reports/ai-context/  Operational runbooks for routing, save/validation, persistence, composition
+├── scripts/             Run scripts (Java 8 and Java 17 variants), property updaters
+├── configuration/       Code style, Checkstyle, formatter configs
+├── .github/workflows/   GitHub Actions: Jenkins trigger, SonarCloud
+├── AGENTS.md            Operational ground truth for AI/human contributors
+├── CLAUDE.md            Entry point for AI assistants — points to AGENTS.md and docs/
+└── EXPANDABLE_BLOCKS_AGENT_INSTRUCTIONS.md  Debugging runbook for accordion-style UIs
+```
+
+For the module breakdown in detail, see [`docs/detailed-design/detailed-design.md`](./docs/detailed-design/detailed-design.md) §2.
+
+---
+
+## Quick start (local development)
+
+### Prerequisites
+
+- Java 8 (default branches) **or** Java 17 (branches whose name contains `java17` / `java_17`).
+- Maven 3.8.x.
+- MySQL 8.x (local instance for development).
+- Network access to a CIAT environment if connecting to shared test data:
+  - Test (CIAT Palmira): **FortiClient VPN**.
+  - Staging / Production (AWS): **GlobalProtect VPN**.
+
+### Clone and build
+
+```bash
+git clone https://github.com/CCAFS/MARLO.git
+cd MARLO
+git checkout aiccra-staging   # branch off here for new work
+```
+
+### Configure local properties
+
+The properties files holding credentials are gitignored. Bootstrap from the provided template:
+
+```bash
+cp marlo-web/src/main/resources/config/marlo-test.properties \
+   marlo-web/src/main/resources/config/marlo-dev.properties
+# edit marlo-dev.properties to point at your local MySQL and credentials
+```
+
+Active Spring profile selects which file is loaded: `marlo-${spring.profiles.active}.properties`. Available profiles: `dev`, `api`, `pro`, `test`.
+
+### Run
+
+Use the run script that matches the branch's Java version:
+
+```bash
+# Java 8 branches
+scripts/run-marlo-java8.sh           # macOS / Linux
+scripts/run-marlo-java8.bat          # Windows
+
+# Java 17 branches (name contains java17 / java_17)
+scripts/run-marlo-java17.sh
+scripts/run-marlo-java17.bat
+```
+
+Flyway migrations apply automatically on Tomcat startup. The app comes up on the local Cargo Tomcat instance.
+
+### Quality gates
+
+```bash
+mvn checkstyle:check     # mandatory before commit
+mvn test                  # unit tests
+```
+
+SonarCloud and Snyk run automatically on push / PR via GitHub Actions.
+
+---
+
+## Branching & release model
+
+| Branch | Role | Rules |
+|---|---|---|
+| `AICCRA` | Production | Merge-only from `aiccra-staging`. **No direct commits.** |
+| `aiccra-staging` | Stable integration | All feature branches merge here. |
+| `aiccra-dev` | Experimentation | Highly unstable; integration testing only. |
+| `aiccra-<slug>` | Feature branches | Created from `aiccra-staging`; merged back into it. |
+
+CI/CD: a push to any branch triggers the Jenkins job `marlo-<branch-suffix>`. Slack receives success/failure notifications.
+
+---
+
+## Documentation map
+
+The repository follows a **Spec-Driven Development (SDD)** methodology. The documents below form the constitutional baseline; module-level work lives under `docs/specs/`.
+
+### Constitutional baseline
+
+- [`AGENTS.md`](./AGENTS.md) — operational ground truth: language rules, file headers, code style, Checkstyle, migration naming, specificity workflow, file organization, run scripts.
+- [`CLAUDE.md`](./CLAUDE.md) — entry point for AI assistants; lists the 12 hard rules and the doc-reading order.
+- [`docs/prd.md`](./docs/prd.md) — Product Requirements: problem, personas, goals, success metrics, scope, user stories, acceptance, assumptions, open questions.
+- [`docs/system-design/design.md`](./docs/system-design/design.md) — UI/UX system blueprint: information architecture, screen inventory, navigation, layout patterns, components, accessibility.
+- [`docs/detailed-design/detailed-design.md`](./docs/detailed-design/detailed-design.md) — technical blueprint: modules, data model, phase replication contract, API surface, save pipeline, security, observability, testing, ADR snapshots.
+
+### Spec methodology and taxonomy
+
+Every module spec under `docs/specs/` MUST follow these templates:
+
+- [`docs/specs/general-setup/requirements.md`](./docs/specs/general-setup/requirements.md)
+- [`docs/specs/general-setup/design.md`](./docs/specs/general-setup/design.md)
+- [`docs/specs/general-setup/task.md`](./docs/specs/general-setup/task.md)
+
+Spec folders live under:
+
+- `docs/specs/domain/<module>/` — module-level specs (projects, deliverables, innovations, OICRs, POWB, annual report, QA, admin, auth, BI, AI services).
+- `docs/specs/enhancement/<feature>/` — cross-cutting features.
+- `docs/specs/bugfix/<slug>/` — bug-driven specs needing structured trace.
+- `docs/specs/epic/<name>/` — multi-spec initiatives (e.g., `epic/java-17-cutover/`, `epic/tenant-onboarding/`).
+
+### Operational runbooks
+
+The `reports/ai-context/` folder holds authoritative operational guides for the most-touched flows:
+
+- [`frontend-composition-map.md`](./reports/ai-context/frontend-composition-map.md) — FTL composition (`#include`, `#import`, macros, expandable-block templates).
+- [`save-validation-matrix.md`](./reports/ai-context/save-validation-matrix.md) — save pipeline matrix for the 10 critical sections.
+- [`persistence-replication-managerimpl.md`](./reports/ai-context/persistence-replication-managerimpl.md) — phase replication contract in `ManagerImpl` save / delete chains.
+- [`struts-critical-routing-catalog.md`](./reports/ai-context/struts-critical-routing-catalog.md) — Struts routing catalog with action classes and view results.
+- [`interceptor-validator-playbook.md`](./reports/ai-context/interceptor-validator-playbook.md) — interceptor stacks and `Action.validate()` patterns.
+- [`EXPANDABLE_BLOCKS_AGENT_INSTRUCTIONS.md`](./EXPANDABLE_BLOCKS_AGENT_INSTRUCTIONS.md) — debugging accordion-style list UIs.
+
+---
+
+## Hard rules (non-negotiable)
+
+These rules are constitutional. Deviations require an explicit, justified Decision Log entry inside the relevant module spec.
+
+1. **Phased data is forward-only.** Saves replicate to current and future phases; past phases are immutable.
+2. **Save pipeline pattern** is mandatory for critical sections: `Action.validate()` guarded by `if (save)` → `Validator` → manager save chain.
+3. **Spring MVC owns `/api/*`.** Struts is excluded from this prefix. Do not introduce new `*.json` Struts paths beyond existing patterns.
+4. **Specificities** (per-Global-Unit feature flags) go through the `parameters` + `custom_parameters` flow, with constants in *both* `APConstants.java` files (`marlo-data/` and `marlo-web/`).
+5. **Schema changes ship as Flyway migrations** under `marlo-web/src/main/resources/database/migrations/` with `V<major>_<minor>_<patch>_<YYYYMMDD>_<HHMM>__<Description>.sql` naming.
+6. **GPL header** on every new Java file (template in `AGENTS.md`).
+7. **Code style:** 2-space indent, 120 char line limit, braces on same line, mandatory blocks for `if/while/for/do`, max file length 3500 lines. `mvn checkstyle:check` is a gate.
+8. **English only** in code, identifiers, and inline comments. User-facing strings MUST be i18n-keyed.
+9. **Branching:** never commit directly to `AICCRA`.
+10. **Run scripts** match the branch's Java version (Java 17 only on branches containing `java17` / `java_17`).
+11. **Dependency floors** (post-January 2026 SETI baseline) MUST NOT be downgraded.
+12. **Never commit credentials.** `marlo-${profile}.properties` is gitignored.
+
+---
+
+## Security
+
+MARLO completed a comprehensive security modernization in January 2026 (executed by SETI). All critical vulnerabilities were remediated and the dependency baseline above was established. Snyk scans run on the monorepo each release cycle. Semi-annual reviews are recommended for legacy components (Pentaho, iText).
+
+To report a security issue, contact the IBD team at `Marlosupport@cgiar.org` rather than opening a public issue.
+
+---
+
+## Contributing
+
+1. Read [`CLAUDE.md`](./CLAUDE.md) and [`AGENTS.md`](./AGENTS.md).
+2. Branch from `aiccra-staging` as `aiccra-<slug>`.
+3. Draft the spec under `docs/specs/...` (`requirements.md` → `design.md` → `task.md`).
+4. Get the spec reviewed before implementation.
+5. Implement, keeping `task.md` up to date with verification notes.
+6. Update relevant `reports/ai-context/*.md` files when the change alters routing, validation, replication, or composition contracts.
+7. Open a PR into `aiccra-staging`. Ensure Checkstyle, SonarCloud, and Snyk are clean.
+
+---
+
+## Support & contact
+
+- **MARLO Support:** `Marlosupport@cgiar.org`
+- **Maintainer:** IBD Team — Alliance of Bioversity International and CIAT
+- **GitHub:** [`CCAFS/MARLO`](https://github.com/CCAFS/MARLO)
+- **Wiki:** [github.com/CCAFS/MARLO/wiki](https://github.com/CCAFS/MARLO/wiki)
+- **Support tickets** are managed through Freshservice; access requests follow the data-governance ticketing process.
+
+---
+
+## License
+
+MARLO is distributed under the [GNU General Public License v3](./LICENSE). Every Java source file MUST carry the GPL header documented in [`AGENTS.md`](./AGENTS.md).

--- a/docs/detailed-design/detailed-design.md
+++ b/docs/detailed-design/detailed-design.md
@@ -1,0 +1,570 @@
+# MARLO — Detailed Design (Technical Blueprint)
+
+**Status:** Living document. Version: 1.0 (Constitutional Baseline).
+**Owner:** IBD Team — Alliance of Bioversity International and CIAT.
+**Last Updated:** 2026-04-30.
+**Related:** [docs/prd.md](../prd.md), [docs/system-design/design.md](../system-design/design.md), [AGENTS.md](../../AGENTS.md), [reports/ai-context/*](../../reports/ai-context/).
+
+> This document captures the *technical* shape of MARLO: modules, data, APIs, security, observability, and testing. It encodes the patterns the codebase already follows (see `AGENTS.md` and `reports/ai-context/*`) and the architectural commitments that future module specs MUST honor.
+
+---
+
+## 1. System Overview
+
+MARLO is a Java EE web application that:
+
+- Persists transactional research-management data in a phase-aware MySQL database.
+- Renders form-driven UIs over Apache Struts 2 + FreeMarker.
+- Exposes a Spring MVC REST API under `/api/*` for trusted integrations.
+- Enforces authentication and authorization via Apache Shiro + CGIAR Active Directory.
+- Replicates phased data forward through a recursive `ManagerImpl` pattern.
+- Feeds an external Microsoft Fabric / Power BI ecosystem (Bronze / Silver / Gold).
+- Hosts AI services (Text Mining, Reports Generator, Chatbot) on AWS that consume MARLO data via the REST API and the database.
+- Runs on AWS for production (Virginia) and on-premise at CIAT Palmira for Test, with Staging coming online.
+
+### 1.1 High-level architecture
+
+```
+                +-----------------------+        +---------------------+
+                |  CGIAR Active         |        |  CLARISA            |
+                |  Directory            |        |  (institutions,     |
+                +-----------+-----------+        |  geo, taxonomy)     |
+                            |                    +----------+----------+
+                       (Shiro auth)                         |
+                            v                               | (REST)
++--------------------+  +---v-------------------+   +-------v---------+
+|  End-user browser  |->| MARLO Web (Tomcat 9) |-->|  CLARISA client |
+|  (FTL + jQuery)    |  | Struts 2 + Spring MVC|   +-----------------+
++--------------------+  +---+-------------------+
+                            |
+                            | Hibernate (HQL/SQL)
+                            v
+                   +--------+----------+    +----------------------+
+                   |  AWS RDS (MySQL)  |    | AWS S3 (backups,     |
+                   +--------+----------+    | document store)      |
+                            |               +----------------------+
+                            | (extract / pipelines)
+                            v
+                   +--------+----------+
+                   | Microsoft Fabric  |
+                   | Lakehouse (Bronze |
+                   | / Silver / Gold)  |
+                   +--------+----------+
+                            |
+                            v
+                   +--------+----------+    +----------------------+
+                   | Power BI Service  |<-->| Public embed tool    |
+                   +-------------------+    +----------------------+
+
+                   +-------------------+    +----------------------+
+                   | AWS Lambda        |    | AWS Bedrock          |
+                   | (AI/automation)   |<-->| (Claude, Titan)      |
+                   +--------+----------+    +----------+-----------+
+                            |                          |
+                            v                          v
+                   +--------+--------------------------+----+
+                   | Amazon OpenSearch (vector indices)     |
+                   +----------------------------------------+
+```
+
+### 1.2 Deployment topology
+
+- **Production (AWS, Virginia)** — multiple EC2 instances: core application, frontend, CLARISA integration, automation, backup. Lambda for specific AI/automation tasks. RDS MySQL as system of record. S3 for backups and documents.
+- **Test (CIAT Palmira)** — on-premise; reachable via FortiClient VPN.
+- **Staging** — being built out to mirror Production behind GlobalProtect VPN.
+- **CI/CD** — Jenkins (https://automation.prms.cgiar.org/) triggered by GitHub Actions workflow `jenkins-trigger.yml` on every push. SonarCloud workflows (`sonarcloud.yml`, `sonartest.yml`) provide static analysis.
+
+---
+
+## 2. Domain Modules & Responsibilities
+
+MARLO is structured as a multi-module Maven project. The aggregator (`marlo-aggregator`, `pom.xml` at repo root) drives a build over five modules.
+
+| Module | Responsibility | Key contents |
+|---|---|---|
+| `marlo-parent` | Dependency and plugin management. No executable code. | `pom.xml` declares `struts2`, `hibernate`, `spring`, `shiro`, `mysql`, `flyway`, etc. (see `marlo-parent/pom.xml`). |
+| `marlo-utils` | Pure utility classes (dates, strings, file processing for Excel/CSV/PDF, JSON helpers, constants). | `org.cgiar.ccafs.marlo.utils.*`. |
+| `marlo-core` | Cross-cutting configuration: Shiro security wiring, Hibernate session factory, custom security utilities. | `MarloShiroConfiguration`, `MarloLocalSessionFactoryBean`, `MarloDatabaseConfiguration`. |
+| `marlo-data` | Domain layer: JPA/Hibernate entities (`model`), `dao`/`mapper`, Manager interfaces and implementations. Audit listeners. | `org.cgiar.ccafs.marlo.data.{model,dao,manager,mapper}`; `IAuditLog`, `HibernateAuditLogListener`, `AuditColumnHibernateListener`. |
+| `marlo-web` | Web tier: Struts actions, REST controllers, FreeMarker templates, validators, interceptors, Spring MVC config, web resources, SQL migrations. | `org.cgiar.ccafs.marlo.action.*`, `rest.controller.v2.*`, `validation.*`, `interceptor.*`. |
+
+### 2.1 Action package map (`marlo-web`)
+
+Top-level Struts action packages and their domains:
+
+- `action/ai` — AI-related screens (e.g., `AiAction`).
+- `action/annualReport` — Annual Report synthesis sections.
+- `action/bi` — BI dashboard hub (`BiReportsAction`).
+- `action/center` — CGIAR Center program flows.
+- `action/crp` — CRP-level admin and shared flows.
+- `action/deliverable` — Deliverable lifecycle screens.
+- `action/downloads` — File/report downloads.
+- `action/funding` — Funding sources.
+- `action/home` — Home dashboard.
+- `action/impactpathway` — Impact pathway management.
+- `action/json` — Existing JSON endpoints (use punctually only).
+- `action/powb` — POWB synthesis sections.
+- `action/projects` — Project / cluster CRUD (Description, Partners, Locations, Activities, Deliverable, Innovation, Highlight, Case Study, Outcomes, Budgets…).
+- `action/publications` — Publication flows.
+- `action/qa` — Quality Assurance flows.
+- `action/report` — Reporting (legacy, see also `annualReport`).
+- `action/summaries` — PDF / export summaries.
+- `action/superadmin` — System-level administration.
+- `action/synthesis` — Cross-CRP synthesis.
+- `action/tip` — Technology Innovation Profile.
+- `action/BaseAction.java` — Common base class (inject `APConfig`, exposes `hasSpecificities`, current user/phase/session helpers).
+- `action/MapGeolocation.java` — Geolocation helper action.
+- `action/UnhandledExceptionAction.java` — Global error handler.
+
+### 2.2 REST package (`marlo-web/src/main/java/.../rest`)
+
+- `rest/controller/v2/controllist/` — REST endpoints (e.g., `Deliverables`, `Innovations`, `ExpectedStudies`, `Projects`, `QAToken`, `Institutions`, `GeneralLists`, `Expenditures`, `ProgressTowards`, `SrfLists`).
+- `rest/controller/v2/controllist/items/` — sub-resource endpoints.
+- `rest/dto/` — Data transfer objects (separated from `data.model` entities).
+- `rest/mappers/` — MapStruct mappers between entities and DTOs.
+- `rest/services/` — Service-layer logic for REST.
+- `rest/errors/` — REST error handling and standardized responses.
+
+### 2.3 Configuration packages (`marlo-web` core)
+
+- `config/ApplicationContextConfig.java` — Spring application context.
+- `config/MarloRestApiConfig.java` — Spring MVC for `/api/*`.
+- `config/MarloSwaggerConfiguration.java` — Springdoc OpenAPI.
+- `config/MarloFlywayConfiguration.java` — Flyway migrations.
+- `config/MarloBusinessIntelligenceConfiguration.java` — BI config.
+- `config/WebAppInitializer.java` — Servlet container bootstrap.
+- `interceptor/` — Struts interceptors (auth, CRP validation, edit gates).
+- `validation/` — Action-side validators (e.g., `ProjectDescriptionValidator`).
+- `security/` — App-level security helpers complementing Shiro.
+
+---
+
+## 3. Data Model & Entities
+
+### 3.1 System of record
+
+- **Engine:** MySQL (AWS RDS in production).
+- **ORM:** Hibernate 5.4.x via JPA-style annotations on entities under `marlo-data/.../data/model`.
+- **Connection pool:** HikariCP (≥ 5.x post-Jan 2026).
+- **Schema migrations:** Flyway 4.0.1 (`marlo-web/src/main/resources/database/migrations/`); no raw schema changes outside migrations.
+
+### 3.2 Entity scale
+
+The data layer holds **544 entity classes**, **456 manager interfaces** (with corresponding `*Impl`), and **455 DAOs** at the time of writing. Every persisted entity follows the layered pattern (see §3.4).
+
+### 3.3 Phase-aware data model
+
+Phases are first-class. The `phases` table enumerates every cycle moment (POWB / UpKeep / AR per year). Phased entities (deliverables, partners, innovations, OICRs, etc.) carry an explicit `phase_id` foreign key.
+
+**Replication contract** (per `reports/ai-context/persistence-replication-managerimpl.md`):
+
+1. Saves are forward-only: changes apply to current and future phases, never past.
+2. From `PLANNING`, replicate through every `phase.getNext()` until exhausted.
+3. From `REPORTING`, replicate to `phase.getNext().getNext()` (UpKeep) and onward.
+4. Delete operations mirror save operations across the same phase chain.
+5. Section-specific skip rules apply (e.g., publication deliverables skip replication).
+6. Duplicate prevention filters target phases before insert.
+
+Any change to a `ManagerImpl` save path MUST preserve this contract. Add tests that exercise the replication chain end-to-end.
+
+### 3.4 Layered persistence pattern
+
+For every persisted entity:
+
+- **Manager interface** — defines business operations (e.g., `DeliverableFundingSourceManager`).
+- **ManagerImpl** — implements business logic, including phase replication.
+- **DAO interface** — defines persistence operations.
+- **MySQLDAO** — concrete Hibernate implementation (HQL / SQL queries).
+
+This pattern is non-negotiable: new entities MUST follow it. New code MUST NOT bypass the manager layer to talk to the DAO directly.
+
+### 3.5 Audit logging
+
+- `IAuditLog` interface marks auditable entities.
+- `HibernateAuditLogListener` and `AuditColumnHibernateListener` (in `marlo-data/`) capture changes.
+- Audit columns (`created_by`, `modified_by`, `active_since`, etc.) are populated automatically.
+- Significant write paths MUST keep audit columns intact.
+
+### 3.6 Reference data
+
+- CLARISA-backed: institutions, countries / regions, partner types, indicator taxonomies. Synchronization is integration-driven; do NOT hand-edit these tables.
+- Internal taxonomies: SLOs, IDOs, cross-cutting issues, Scaling Readiness levels, deliverable types, OICR maturity classes — managed via Admin / Super Admin screens and migrations.
+
+### 3.7 Specificity / parameter tables
+
+- `parameters` — one row per (`global_unit_type_id`, `key`) feature flag definition.
+- `custom_parameters` — one row per (`parameter_id`, `global_unit_id`) override.
+- `category = '2'` and `format = '1'` mark a specificity (boolean-like).
+
+The constitutional flow for adding a specificity is documented in `AGENTS.md` §"Specificity Implementation Guide" and MUST be followed.
+
+---
+
+## 4. API Surface & Contracts
+
+### 4.1 Two routing layers
+
+| Layer | Pattern | Owner | Purpose |
+|---|---|---|---|
+| Struts 2 | `*.do`, occasionally `*.json` | Internal UI flows | All form-driven user interactions. |
+| Spring MVC | `/api/*` | External consumers | REST API for trusted integrations (CLARISA, AI services, BI ingestion). |
+
+`struts.xml` enforces the boundary: `struts.action.excludePattern = /api/*`.
+
+### 4.2 Internal Struts routing
+
+- Mapping files: `struts.xml` + per-domain `struts-<area>.xml` (e.g., `struts-projects.xml`, `struts-admin.xml`, `struts-powb.xml`, `struts-annualReport.xml`, `struts-impactPathway.xml`, `struts-fundingSources.xml`, `struts-bi.xml`, `struts-ai.xml`, `struts-qa.xml`, `struts-superadmin.xml`, `struts-publications.xml`, `struts-studies.xml`, `struts-summaries.xml`, `struts-synthesis.xml`, `struts-tip.xml`, `struts-data.xml`, `struts-home.xml`, `struts-json.xml`, `struts-api.xml`, `struts-report.xml`, `struts-center-*.xml`, plus legacy `struts-powb2019.xml` / `struts-annualReport2018.xml`).
+- Critical routing catalog: see `reports/ai-context/struts-critical-routing-catalog.md`.
+
+### 4.3 Interceptor stacks
+
+Defined under `<package name="marlo-default" namespace="/" extends="struts-default">` in `struts.xml`. Key stacks (per `reports/ai-context/interceptor-validator-playbook.md`):
+
+- `crpAdminStack` — auth/session + admin access + `canEditCrpAdmin`.
+- `impactPathwayStack` — auth/session + `canEditImpactPathway`.
+- `editProjectsStack` — auth/session + `canEditProject`.
+- `editFSStack` — auth/session + `editFunding`.
+- `editPowbStack` — auth/session + `canEditPowbSynthesis`.
+- `editReportSynthesisStack` — auth/session + `canEditReportSynthesis`.
+- `editProjectListStack` — lightweight, used before per-action interceptors (`editDeliverable`, `editInnovation`, `editAi`, `editHighlight`, `editCaseStudy`, `editProjectOutcome`).
+- `homeStack` — landing/dashboard stack.
+- `projectListStack` — includes `SecurityControl`; used for existing JSON endpoints.
+
+Constitutional rules:
+
+1. Every new `.do` action MUST declare an interceptor stack — no anonymous defaults for write paths.
+2. Stacks MUST run permission checks (`canEdit*`, `editFunding`, `accessibleAdmin`) before action execution.
+3. Action-side `validate()` MUST be guarded with `if (save) { ... }` and call the matching `Validator`.
+
+### 4.4 REST API (Spring MVC, `/api/v2/*`)
+
+- Controllers live in `rest/controller/v2/controllist/`.
+- DTOs are explicit; entities are not serialized directly.
+- MapStruct mappers (`rest/mappers/`) translate entities ↔ DTOs.
+- Errors flow through `rest/errors/`.
+- OpenAPI is provided by Springdoc (replaces legacy Springfox/Swagger).
+- Authentication: REST uses Shiro-backed token-based auth (e.g., `QAToken` controller). Public-write surfaces are not constitutional.
+
+API design principles:
+
+1. Resources are nouns; verbs come from HTTP methods.
+2. Versioning is path-based (`/api/v2/...`); breaking changes increment the version.
+3. Pagination, filtering, and sort parameters follow consistent query-string conventions.
+4. Errors are JSON with stable `code` + human-readable `message` fields.
+
+### 4.5 Existing Struts JSON endpoints
+
+`*.json` extensions are configured (`struts.action.extension = do,,json`). They exist for legacy reasons and are scoped to existing patterns. Per `AGENTS.md`: do NOT introduce new JSON paths unless an existing pattern in the same module mandates it.
+
+---
+
+## 5. Backend Workflows & Business Rules
+
+### 5.1 Save pipeline (critical)
+
+Per `reports/ai-context/save-validation-matrix.md` and `interceptor-validator-playbook.md`:
+
+```
+HTTP request -> Struts mapping -> Interceptor stack -> Action.validate() -> Validator -> Action.save() / Manager save chain
+```
+
+For every critical save section:
+
+1. The interceptor stack runs first (auth, session, edit rights).
+2. Struts triggers `validate()`.
+3. The action guards with `if (save) { ... validator.validate(this, entity, true); }`.
+4. The validator populates invalid fields and action errors.
+5. The action checks `hasErrors()` / invalid field map and either returns INPUT or proceeds to persist.
+6. The Manager's save method persists the current entity, then recursively replicates forward (§3.3).
+7. The audit listeners record the change.
+
+### 5.2 Phase replication rules (recap)
+
+- Planning save → replicate to all next phases.
+- Planning delete → remove from all next phases.
+- Reporting save → replicate to upkeep (`next.next`) and forward.
+- Reporting delete → remove from upkeep chain forward.
+- Section-specific skip flags (e.g., `isPublication`) MUST be honored.
+
+### 5.3 Specificity gating
+
+Branch behavior on a specificity flag:
+
+```java
+if (this.hasSpecificities(APConstants.MY_SPECIFICITY_KEY)) {
+  // enabled behavior
+} else {
+  // default behavior
+}
+```
+
+In FTL:
+
+```ftl
+[#if action.hasSpecificities('my_specificity_key')]
+  [#-- enabled fragment --]
+[/#if]
+```
+
+The constant value MUST equal the `parameters.key`. Both `APConstants.java` files (one in `marlo-data/`, one in `marlo-web/`) MUST be kept in sync.
+
+### 5.4 Notifications and emails
+
+- Notifications are tracked in dedicated tables and exposed in Admin.
+- Outbound email templates are stored under `marlo-web/src/main/resources/template/`.
+- Email tracking and delivery state are visible to admins.
+- Real-time UI notifications use Pusher (`pusher-app.js`).
+
+### 5.5 Background jobs
+
+- Quartz scheduling (`quartz.properties`) runs periodic tasks (e.g., AICCRA-specific reminders, automation triggers).
+- Daily MySQL → S3 backup is operated outside the JVM (scripted on the AWS side).
+- AWS Lambda functions handle AI-side processing and async ingestion to OpenSearch.
+
+---
+
+## 6. Frontend Architecture & State Boundaries
+
+### 6.1 Stack
+
+- **Templating:** FreeMarker 2.x (`.ftl`) — pull-based MVC with Struts2.
+- **Styling:** custom CSS over Bootstrap. Sources under `marlo-web/src/main/webapp/global/css/`.
+- **JS libraries:** managed via Bower (`bower_components/`) plus targeted modules in `marlo-web/src/main/webapp/global/js/` and `crp/js/`.
+- **Build:** Grunt (`Gruntfile.js`) for asset orchestration.
+
+### 6.2 Composition (per `reports/ai-context/frontend-composition-map.md`)
+
+- `[#include]` for layout fragments (`header.ftl`, `main-menu.ftl`, `footer.ftl`, `breadcrumb.ftl`, `messages.ftl`, area submenus).
+- `[#import ... as alias]` for macro libraries (`forms.ftl` → alias `customForm`, area-specific macro files).
+- Macro calls (`[@customForm.input ... /]`) for form rendering.
+- Hidden template macros (`isTemplate=true`) for repeated blocks (cloned/reindexed by JS).
+
+### 6.3 State boundaries
+
+- **Server state** = canonical. The Action populates form-bound objects (e.g., `project`, `deliverable`, `powbSynthesis`, `reportSynthesis`); the form posts indexed collections back.
+- **Client state** = transient form view. `autoSave.js` periodically posts drafts; `fieldsValidation.js` provides client-side validation; `discardChangesPopup.ftl` guards against accidental loss.
+- **No SPA.** The constitutional default is full-page navigation between `.do` actions. AJAX/JSON is reserved for existing patterns only.
+- **No client-side routing.** URL state is server-driven.
+
+### 6.4 Reusable UI primitives
+
+See `docs/system-design/design.md` §8. Constitutional rule: extend existing macros before introducing new components.
+
+---
+
+## 7. Integration Points
+
+| Integration | Direction | Mechanism | Purpose |
+|---|---|---|---|
+| CGIAR Active Directory | Inbound (auth) | Shiro realm | Enterprise SSO. |
+| CLARISA | Outbound | REST | Reference data (institutions, geography, taxonomy). |
+| CGSpace | Outbound | REST | Open-access deposit metadata, DOI lookup. |
+| Power BI Service / Microsoft Fabric | Outbound (data + embed) | DB extracts + REST + JS embed | Dashboards. |
+| AWS S3 | Outbound | AWS SDK | Backups, document storage. |
+| AWS Bedrock (Claude, Titan) | Outbound | AWS SDK | RAG generation, embeddings. |
+| Amazon OpenSearch | Outbound | AWS SDK | Vector indices for Reports Generator. |
+| Pusher | Outbound | WebSocket-like | Real-time UI notifications. |
+| Pentaho Reporting | Embedded | Library | PDF / report generation. |
+| iText | Embedded | Library | PDF assembly. |
+| Apache POI | Embedded | Library | Excel import/export. |
+| Trumbowyg, Chosen, Pickadate, DataTables, Cytoscape | Embedded (frontend) | Bower-managed | Form widgets, tables, graphs. |
+| Jenkins | Outbound (CI) | HTTP webhook | Build pipeline trigger. |
+| SonarCloud | Outbound (CI) | GitHub Action | Static analysis. |
+| Slack | Outbound | Webhook | Build notifications. |
+| Freshservice | External | UI | Support tickets and access requests. |
+
+Integration contracts MUST be explicit. Module specs touching an integration MUST cite the contract version and any rate-limit / SLA assumptions.
+
+---
+
+## 8. Security & Authorization Model
+
+### 8.1 Authentication
+
+- **Primary:** Apache Shiro 1.13.0 with a CGIAR Active Directory realm (`adauth-5.6.jar` packaged under `marlo-web/src/main/resources/libs`).
+- **Fallback:** Internal users with MD5-hashed passwords (legacy; new accounts SHOULD use AD when possible).
+- **Session:** server-side, container-managed; protected by Shiro session manager.
+- **Production network:** GlobalProtect VPN required.
+- **Test network:** FortiClient VPN required.
+
+### 8.2 Authorization layers
+
+1. **Authentication (`users` table)** — identity.
+2. **Project access (`crp_users` table)** — which Programs/Platforms a user can access.
+3. **Role assignment (`user_role` table)** — which permissions the user holds via roles.
+
+Roles (per Technical Overview §15.1):
+
+- Super Admin — system-wide.
+- Admin — project-level (Program/Platform/Center).
+- Project / Cluster Leader — strategic leadership.
+- Project / Cluster Coordinator — operational coordination.
+- PMU — administrative & compliance.
+- QA / Reviewer — phase-level QA.
+- Guest User — restricted external collaboration.
+
+Cluster scope is established via Partner Institutions, ensuring contextual access.
+
+### 8.3 Edit gates (per-section)
+
+Interceptors (`canEditProject`, `canEditAi`, `canEditDeliverable`, `editFunding`, `canEditPowbSynthesis`, `canEditReportSynthesis`, `canEditImpactPathway`, `canEditCrpAdmin`, `accessibleAdmin`, `canEditCrp`, `canEditSynthesis`, `canEditPublication`, `editInnovation`, `editHighlight`, `editCaseStudy`, `editProjectOutcome`, `editFunding`) gate mutating actions before they reach the action class.
+
+### 8.4 REST authentication
+
+- `/api/*` endpoints authenticate via tokens (e.g., `QAToken`) wired through Shiro.
+- DTO boundaries prevent accidental exposure of internal fields.
+- `errors/` package provides standardized 4xx / 5xx responses.
+- Public unauthenticated read endpoints, if any, MUST be explicitly enumerated in their controller and reviewed in module specs.
+
+### 8.5 Web security hardening (post-Jan 2026)
+
+The SETI 2026 modernization completed:
+
+- Apache Struts2 ≥ 6.4.0.
+- Tomcat Catalina ≥ 9.0.96.
+- Spring Framework ≥ 5.3.39.
+- Jackson ≥ 2.17.x.
+- HikariCP ≥ 5.x.
+- Springdoc OpenAPI replaces Springfox/Swagger 2.9.2.
+- Groovy ≥ 2.4.21.
+
+These versions are constitutional floors. Downgrades require an explicit, documented rationale and PMU sign-off.
+
+### 8.6 Data security
+
+- Database credentials are environment-scoped (`marlo-${profile}.properties`).
+- Property files with credentials (e.g., `marlo-dev.properties`) are git-ignored.
+- Backups encrypted at rest (S3 SSE).
+- Network access controlled by VPN policy.
+
+### 8.7 Vulnerability management cadence
+
+- Snyk scans on the monorepo each release cycle.
+- Semi-annual review of legacy components flagged in §16.4 (Pentaho, iText).
+- New critical CVEs introduced by a change block merge to `aiccra-staging`.
+
+---
+
+## 9. Error Handling & Observability
+
+### 9.1 Logging
+
+- SLF4J + Logback (`logback.xml`).
+- Per-class logger (`LoggerFactory.getLogger(...)`).
+- `INFO` for high-level flow, `WARN` for recoverable anomalies, `ERROR` for failures with stack trace.
+- No `System.out` / `printStackTrace` in production code.
+
+### 9.2 Action-level error handling
+
+- `UnhandledExceptionAction` is the global Struts fallback.
+- Error views: `WEB-INF/global/views/403.ftl`, `404.ftl`, `500.ftl`.
+- User-visible errors flow through the page-level message banner (`messages.ftl`); never expose stack traces.
+
+### 9.3 REST error handling
+
+- Centralized in `rest/errors/`.
+- Errors return JSON with stable shape (`code`, `message`, optional `details`).
+- 4xx for client errors; 5xx for server errors.
+- DTO validation errors include the field path.
+
+### 9.4 Observability
+
+- **Operational dashboards** — QA Module and Cluster Completeness Status (Power BI) provide near-real-time operational visibility.
+- **Application metrics** — current logging is the primary signal; dedicated APM (e.g., New Relic, Elastic APM) is an open gap.
+- **Alerting** — Slack integration for build failures; production runtime alerting is operationally managed and an open gap for this constitution.
+- **Backups** — daily backup status is tracked operationally; failures should escalate to the support team.
+
+### 9.5 Rate limiting
+
+- Internal `.do` actions inherit Tomcat-level concurrency limits.
+- REST endpoints are not currently rate-limited at the application layer — an open gap if external partner usage grows.
+
+---
+
+## 10. Testing Strategy
+
+### 10.1 Static analysis
+
+- **Checkstyle** — `mvn checkstyle:check` against `configuration/marlo-checkstyle.xml`. Gate for merges.
+- **SonarCloud** — automated on PRs (`.github/workflows/sonarcloud.yml`, `sonartest.yml`).
+- **Snyk** — security scans in the modernization cycle.
+
+### 10.2 Unit tests
+
+- Java unit tests use JUnit 4.13.2 (`junit.version` in `marlo-parent/pom.xml`).
+- Manager-layer logic SHOULD have unit tests, especially for phase replication rules.
+- Existing coverage is uneven across the data layer; new specs MUST add tests for any new save path.
+
+### 10.3 Integration / regression tests
+
+- QA team operates a structured manual test plan (see Technical Overview §11) covering functional, regression, UI, compatibility scenarios.
+- Test cases live in Jira (Xray-style). Defects flow through Jira lifecycle (report → fix → retest → close).
+- Constitutional commitment: changes to a critical save section (per `reports/ai-context/save-validation-matrix.md`) MUST be retested against their `Validator` and interceptor stack.
+
+### 10.4 Non-functional testing
+
+- Load/stress/performance/usability testing combine black-box, white-box, and grey-box methodologies (Technical Overview §11).
+- Load tests focus on end-of-cycle peaks (annual planning and reporting deadlines).
+
+### 10.5 BI testing
+
+- Each BI release passes through Dev / Test / Prod deployment pipelines with dedicated QA validation per stage.
+
+### 10.6 AI service testing
+
+- AI services include grounding rules: every chatbot response cites sources. A formal hallucination-rate evaluation harness is an open gap (see PRD §9).
+
+---
+
+## 11. Technical Constraints & Assumptions
+
+### 11.1 Hard constraints
+
+1. **Java + Struts2 + Hibernate + Spring + FreeMarker + Tomcat 9 + MySQL** — the constitutional stack. Module specs MUST work within it.
+2. **GPL license** — all source contributions inherit the project's GPL license; the file header in `AGENTS.md` is mandatory.
+3. **Code style** — Eclipse formatter (`configuration/ccafs-java-style-config.xml`), 2-space indent, 120 char line limit, braces on same line, mandatory blocks for `if/while/for/do`. Max file length 3500 lines (Checkstyle).
+4. **Naming** — package regex `^[a-z]+(\\.[a-z][a-z0-9]*)*$`; `Action` suffix mandatory for Struts actions (Struts convention).
+5. **English only** — code, identifiers, inline comments. User-facing content is i18n-keyed (per `AGENTS.md`).
+6. **Phased data is forward-only** — past phases are immutable.
+7. **Multi-module Maven layout** — adding a top-level module is a constitutional event.
+8. **Spring MVC owns `/api/*`** — Struts is excluded from this prefix.
+9. **Branch protection** — `AICCRA` (production) accepts merges only from `aiccra-staging`. Feature branches start from `aiccra-staging`.
+
+### 11.2 Soft constraints (assumptions that may evolve)
+
+- The platform targets a desktop-first browser experience.
+- The Power BI / Microsoft Fabric ecosystem remains the analytics substrate.
+- AWS remains the production cloud.
+- Partner programs follow a phased annual cycle (POWB / UpKeep / AR).
+
+### 11.3 Run scripts
+
+- Java 8 branches: `scripts/run-marlo-java8.sh` (or `.bat`).
+- Java 17 branches: `scripts/run-marlo-java17.sh` (or `.bat`). Use only when the branch contains `java17` / `java_17`.
+- Local property files (`marlo-dev.properties`) are gitignored; bootstrap from `marlo-test.properties` template.
+
+### 11.4 Environment / configuration
+
+- Spring profiles: `dev`, `api`, `pro`, `test`. The active profile selects `marlo-${spring.profiles.active}.properties`.
+- Local Tomcat via Cargo Maven plugin; production Tomcat 9 on EC2.
+
+---
+
+## 12. Architecture Decision Records (ADR snapshots)
+
+These are the decisions that shape MARLO at constitution time. Future ADRs SHOULD live under `docs/specs/general-setup/decisions/` (or per-module spec `decisions/` folders) and reference this baseline.
+
+| # | Decision | Status | Notes |
+|---|---|---|---|
+| ADR-1 | Struts 2 for internal flows; Spring MVC for `/api/*` | Accepted | Boundary enforced by `struts.action.excludePattern`. |
+| ADR-2 | FreeMarker as the view engine | Accepted | All views are `.ftl`; no JSP for new work. |
+| ADR-3 | Hibernate with manual layered managers/DAOs | Accepted | No JPA repositories or Spring Data; preserve the explicit pattern. |
+| ADR-4 | Forward-only phase replication in `ManagerImpl` | Accepted | Recursive across `phase.getNext()`. |
+| ADR-5 | Specificity feature flags via `parameters` + `custom_parameters` | Accepted | Standard feature-flag mechanism for per-Global-Unit behavior. |
+| ADR-6 | Apache Shiro for authentication and authorization | Accepted | CGIAR AD is the primary realm; internal MD5 fallback retained for legacy. |
+| ADR-7 | Microsoft Fabric Lakehouse + Power BI for analytics | Accepted | Bronze / Silver / Gold; refresh every 8 hours (Results) / 30 minutes (QA). |
+| ADR-8 | AWS Bedrock (Claude + Titan) + OpenSearch for AI services | Accepted | Multi-stage RAG pipelines; responses cite sources. |
+| ADR-9 | Jenkins-driven CI/CD with Slack notifications | Accepted | Triggered by GitHub Actions (`jenkins-trigger.yml`). |
+| ADR-10 | SETI January 2026 dependency baseline | Accepted | Constitutional floors documented in §8.5. |
+| ADR-11 | Light theme only | Accepted | See `docs/system-design/design.md` §11. |
+| ADR-12 | No new Struts JSON paths beyond existing patterns | Accepted | Per `AGENTS.md` scope guardrails. |

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,0 +1,275 @@
+# MARLO — Product Requirements Document (PRD)
+
+**Status:** Living document. Version: 1.0 (Constitutional Baseline).
+**Owner:** IBD Team — Alliance of Bioversity International and CIAT.
+**Last Updated:** 2026-04-30.
+**Source Inputs:** `MARLO_Technical_Overview.docx` (April 2026), `AGENTS.md`, `reports/ai-context/*`, current source tree (`marlo-web`, `marlo-data`, `marlo-core`, `marlo-utils`, `marlo-parent`).
+
+> This PRD is the constitutional product baseline for MARLO. It frames *what* MARLO is, *who* it serves, and *what success looks like*. Technical details live in `docs/system-design/design.md` and `docs/detailed-design/detailed-design.md`. Module-level specs live under `docs/specs/`.
+
+---
+
+## 1. Overview & Purpose
+
+MARLO (Managing Agricultural Research for Learning and Outcomes) is an open-source, web-based research-management platform that supports the full Planning, Monitoring, Reporting, and Learning (PMRL) cycle of complex multi-country, multi-stakeholder research programs.
+
+The platform turns monitoring, evaluation, and reporting from a periodic compliance exercise into a continuous, evidence-based workflow embedded in how research teams actually work. It serves as the system of record for annual planning, deliverables, innovations, outcome impact case reports (OICRs), quality assurance (QA), and indicator contributions across one or more research programs ("Global Units" — CRPs, Platforms, or Centers).
+
+This PRD documents requirements for the **AICCRA deployment branch** of MARLO (the active production line maintained by the IBD team), while preserving compatibility with multi-program, multi-platform deployments as a first-class capability.
+
+---
+
+## 2. Problem Statement
+
+Large research programs (e.g., AICCRA, CCAFS) operate across many countries, partner institutions, clusters, and donors. Without a shared platform, they default to spreadsheets, email chains, and fragmented reporting, which produces:
+
+- **Information silos** — cluster data is not comparable across the program.
+- **Inconsistent reporting** — donors receive heterogeneous, hard-to-validate narratives.
+- **Weak traceability** — outputs (deliverables, innovations, OICRs) are disconnected from the indicators they contribute to.
+- **High coordination cost** — leadership lacks a single, authoritative view of progress.
+- **Compliance risk** — open access, FAIR, and quality requirements are not enforced systematically.
+- **Knowledge loss** — historical phases (planning vs. reporting) are overwritten or lost.
+
+MARLO solves this by providing a single, phased, role-based, auditable platform where planning, progress, and reporting data flow through a structured QA process and are exposed both as transactional UIs and as analytical assets (Power BI, AI services).
+
+---
+
+## 3. Target Personas
+
+MARLO serves a layered set of personas. Permissions and UX must reflect each persona's scope.
+
+| Persona | Scope | Primary needs |
+|---|---|---|
+| **Cluster / Project Coordinator** | Cluster | Enter planning data, register deliverables, innovations, OICRs; respond to QA feedback; meet annual cycle deadlines. |
+| **Cluster / Project Leader** | Cluster | Strategic oversight; sign off on cluster narratives; review cluster KPIs. |
+| **PMU (Program Management Unit)** | Program | Compliance and synthesis; track completeness and QA across all clusters; produce annual donor reports. |
+| **QA Reviewer** | Phase | Provide structured feedback on submissions; mark items validated; track 92%+ quality and 95%+ open-access targets. |
+| **Information / Data Owner (KDS)** | Program | Approve definitions, manage data governance, audit changes. |
+| **Program / CRP Admin** | Program | Configure cycles, roles, partners, locations, and program-level taxonomies (SLOs, IDOs, cross-cutting issues). |
+| **Super Admin** | System | Onboard new Programs/Platforms/Centers, control system-wide parameters and specificities. |
+| **Guest User** | Restricted | Limited, controlled external collaboration. |
+| **Public reader** | Public | Consume embedded BI dashboards (e.g., "Deliverables by the Numbers"). |
+| **AI service consumer** | Program | Use chatbot, text mining, and report generation to query/produce content from program data. |
+
+Personas are mapped to system roles defined in `users` / `crp_users` / `user_role` tables (Section 15 of the Technical Overview).
+
+---
+
+## 4. Goals & Success Metrics
+
+### 4.1 Product goals
+
+1. **Reliable system of record** for results-based research management across the full PMRL cycle.
+2. **Embedded QA** — quality and open-access compliance are enforced *during* data entry, not after.
+3. **Phase-safe history** — planning and reporting cycles preserve immutability of past phases.
+4. **Multi-program flexibility** — onboarding a new Program/Platform/Center is a controlled but supported operation.
+5. **Analytics-ready** — operational data flows into a Medallion (Bronze/Silver/Gold) BI architecture.
+6. **AI-augmented** — AI services (text mining, report generator, chatbot) sit *on top of* MARLO data without bypassing its governance.
+7. **Open and self-hostable** — GPL-licensed, hostable by partner institutions.
+
+### 4.2 Quantitative success metrics (baseline derived from AICCRA 2021–2025)
+
+| Metric | Target | Rationale |
+|---|---|---|
+| Open-access compliance on deliverables | ≥ 95% annually | Replicates AICCRA's 2024 96% baseline. |
+| Quality rating on validated deliverables | ≥ 92% | Replicates AICCRA's 2024 baseline. |
+| QA cycle responsiveness — first response SLA | ≥ 85% | Support framework target; current 89%. |
+| QA cycle resolution SLA | ≥ 85% | Support framework target; current 96%. |
+| Backup recoverability | Daily, < 24h RPO | Daily S3 backup process. |
+| Critical CVEs in production dependencies | 0 open | Post-Jan 2026 SETI remediation baseline. |
+| Results BI refresh latency | ≤ 8 hours | Fabric Data Pipeline cadence. |
+| QA dashboard refresh latency (active periods) | ≤ 30 minutes | Operational requirement. |
+
+### 4.3 Qualitative goals
+
+- A **new cluster coordinator can complete one full annual cycle** (planning → progress → reporting) without one-on-one support after a structured onboarding.
+- A **PMU lead can produce a donor-ready annual report** primarily from MARLO outputs (BI + AI Reports Generator).
+- A **partner institution can self-host a MARLO instance** for a new program from public source + this constitution.
+
+---
+
+## 5. Scope
+
+### 5.1 In scope (constitutional baseline)
+
+- Annual Work Plan and Budget (AWPB) — planning per cluster / project.
+- Progress monitoring (continuous, intra-year).
+- Annual Reporting (AR) — narrative + structured indicators + cluster synthesis.
+- Deliverables management (full lifecycle, Open Access, FAIR).
+- Innovation tracking with Scaling Readiness (0–9).
+- OICRs (Outcome Impact Case Reports) with maturity classification.
+- QA workflow with structured feedback comments and validation states.
+- POWB (Plan of Work and Budget) and Annual Report synthesis modules.
+- Impact Pathway management (outcomes, SLOs, IDOs, cross-cutting issues).
+- Funding sources and partner management (CLARISA-integrated).
+- Program / Platform / Center administration (multi-tenant Global Units).
+- User, role, and permission management (CGIAR Active Directory + internal users).
+- Phase-based data model with forward-only replication.
+- Specificity feature flags (`parameters` + `custom_parameters`) for per-Global-Unit behavior.
+- BI dashboard delivery (Power BI + public embedding tool).
+- AI services (text mining, report generator, chatbot) consuming MARLO data via documented contracts.
+- Spring MVC REST API under `/api/*` for external integrations (CLARISA, AI services, BI ingestion).
+- Audit log of significant changes.
+
+### 5.2 Out of scope (constitutional)
+
+- General-purpose project management (Gantt, time tracking, ticketing) — MARLO is not Jira/MS Project.
+- Personal task management — handled by the team's external tools (Freshservice, Jira, Slack).
+- Financial accounting or payroll — MARLO holds budget and expenditure metadata, not transactional finance.
+- New mobile-native clients — current scope is responsive web only.
+- Replacing CGIAR Active Directory — MARLO authenticates *against* it, plus an internal MD5-encrypted fallback.
+- Replacing CLARISA, CGSpace, Power BI, or AWS Bedrock — MARLO integrates with them, it does not reimplement them.
+- Public write APIs — `/api/*` is not a public open-write surface; access is controlled per consumer.
+- Real-time (sub-minute) collaboration — MARLO is form-based with phase-aware persistence, not a live collaborative editor.
+
+### 5.3 Out of scope for the AICCRA branch (today)
+
+- New Struts JSON endpoints beyond existing patterns (per `AGENTS.md` scope guardrails).
+- Reintroducing legacy modules (CCAFS-specific synthesis variants `powb2019`, `annualReport2018`) for new programs — these remain frozen for historical compatibility.
+
+---
+
+## 6. User Stories
+
+User stories are grouped by persona. Each links to the modules where the corresponding feature lives.
+
+### 6.1 Cluster Coordinator
+
+- **US-CC-01 — Plan annual work.** As a Cluster Coordinator, I want to enter my cluster's annual plan (objectives, deliverables, targets, partners) under the active POWB phase so that I can submit a complete plan before the planning deadline.
+- **US-CC-02 — Track deliverable progress.** As a Cluster Coordinator, I want to update deliverable status, dissemination, and quality fields during the year so that progress is visible to PMU and QA.
+- **US-CC-03 — Register innovations and OICRs.** As a Cluster Coordinator, I want to create an innovation with its Scaling Readiness level and link supporting deliverables so that downstream BI and donor reports reflect cluster contributions accurately.
+- **US-CC-04 — Respond to QA feedback.** As a Cluster Coordinator, I want to see QA feedback comments on my entries and resolve them so that my cluster reaches the 92% quality threshold.
+
+### 6.2 QA Reviewer
+
+- **US-QA-01 — Review submissions.** As a QA Reviewer, I want a queue of pending items per cluster and section so that I can systematically validate and comment on them.
+- **US-QA-02 — Add structured feedback.** As a QA Reviewer, I want to attach typed feedback comments to specific fields so that improvements are unambiguous and trackable.
+- **US-QA-03 — Track QA throughput.** As a QA Reviewer, I want a live dashboard of feedback resolution times so that I can hit the 30-minute QA refresh and SLA targets.
+
+### 6.3 PMU / Program Lead
+
+- **US-PMU-01 — Cluster completeness view.** As a PMU lead, I want a real-time completeness dashboard so that I can chase incomplete clusters before the deadline.
+- **US-PMU-02 — Program-wide synthesis.** As a PMU lead, I want to generate the annual report (narrative + indicators + cluster summaries) from MARLO so that donor reporting is consistent.
+- **US-PMU-03 — Generate AI-assisted narratives.** As a PMU lead, I want the AI Reports Generator service to draft cluster-specific narratives grounded in MARLO data so that I can save time without losing evidence linkage.
+
+### 6.4 Program / CRP Admin
+
+- **US-ADM-01 — Configure phases.** As a Program Admin, I want to configure the POWB / UpKeep / AR phases for a year so that the platform's phase-based data flows reflect the program's actual cycle.
+- **US-ADM-02 — Manage roles & partners.** As a Program Admin, I want to assign roles to users by Cluster / Project and manage partner institutions so that access is contextual and accurate.
+- **US-ADM-03 — Toggle specificities.** As a Program Admin, I want to enable or disable a feature behavior (specificity) per Global Unit so that programs can opt into capabilities without forking the platform.
+
+### 6.5 Super Admin
+
+- **US-SA-01 — Onboard a new Global Unit.** As a Super Admin, I want a controlled procedure to register a new CRP / Platform / Center so that the program inherits MARLO's governance with its own configuration.
+- **US-SA-02 — System health visibility.** As a Super Admin, I want notifications, email tracking, and bulk replication tools so that I can operate the platform at scale.
+
+### 6.6 Public reader
+
+- **US-PUB-01 — Consume public dashboards.** As a public reader, I want to view the program's deliverables and FAIR/Open Access metrics through embedded Power BI dashboards so that the program meets its transparency commitments.
+
+### 6.7 AI service consumer
+
+- **US-AI-01 — Conversational data exploration.** As an authenticated stakeholder, I want to query MARLO data through the chatbot with citations and hyperlinks so that I trust the answer is grounded in MARLO content.
+- **US-AI-02 — Innovation extraction.** As a PMU lead, I want the Text Mining service to propose structured innovation candidates from research outputs so that I can validate them rather than transcribing manually.
+
+---
+
+## 7. Acceptance Criteria
+
+Acceptance criteria are stated at the product level. Each module spec under `docs/specs/domain/<module>/` will refine these into concrete, testable rules. Module specs MUST follow the format defined in `docs/specs/general-setup/requirements.md`.
+
+### 7.1 Cross-cutting acceptance
+
+1. **Phase safety** — A save in the current phase MUST replicate forward (current → all future phases) per the rules in `reports/ai-context/persistence-replication-managerimpl.md`. Past phases are immutable.
+2. **Save validation** — Every critical save section MUST follow the `Action.validate()` + `Validator` + interceptor stack pattern documented in `reports/ai-context/save-validation-matrix.md`. Sections without a validator (e.g., `PortfolioManagementAction`) MUST be flagged as risk areas before being changed.
+3. **Permissions** — Every `.do` action MUST be backed by an interceptor stack that enforces edit rights for the section (see `reports/ai-context/struts-critical-routing-catalog.md`). REST endpoints under `/api/*` MUST authenticate via the dedicated REST security path (Apache Shiro + token).
+4. **Auditability** — Significant entity changes MUST be captured by `IAuditLog` / `HibernateAuditLogListener`. Changes to data definitions MUST be tracked through the Freshservice ticketing system.
+5. **Migrations** — Every schema change MUST ship as a Flyway migration under `marlo-web/src/main/resources/database/migrations/` using the naming pattern `V<major>_<minor>_<patch>_<YYYYMMDD>_<HHMM>__<Description>.sql`.
+6. **Specificities (feature flags)** — New conditional behavior MUST be implemented through the `parameters` / `custom_parameters` flow defined in `AGENTS.md` (constants in both `APConstants.java` files; backend uses `BaseAction.hasSpecificities(...)`; frontend uses `action.hasSpecificities('<key>')`).
+7. **i18n** — User-facing strings MUST be placed in `marlo-web/src/main/resources/global.properties` (or program-specific `custom/*.properties`) — never hardcoded in FTL or Java.
+8. **Localization of code** — All code, identifiers, and inline comments MUST be in English (per `AGENTS.md`).
+9. **License header** — Every new Java file MUST carry the GPL header from `AGENTS.md`.
+
+### 7.2 Quality and security acceptance
+
+1. **Checkstyle** — `mvn checkstyle:check` MUST pass against `configuration/marlo-checkstyle.xml`.
+2. **CVEs** — Critical Snyk findings introduced by a change MUST be remediated before merge to `aiccra-staging`.
+3. **Dependency baselines (Jan 2026, post-SETI)** — MUST NOT be downgraded:
+   Struts2 ≥ 6.4.0, Tomcat Catalina ≥ 9.0.96, Spring Framework ≥ 5.3.39, Jackson ≥ 2.17.x, HikariCP ≥ 5.x, Springdoc OpenAPI (replaces Springfox/Swagger 2.9.2), Groovy ≥ 2.4.21.
+4. **QA completeness** — A change to a critical save section MUST be retested against its `Validator` and its interceptor stack before deploy.
+
+### 7.3 Operational acceptance
+
+1. **CI/CD** — Merges to integration branches MUST trigger the Jenkins pipeline. Slack notifications confirm success/failure (existing convention).
+2. **Branching** — `AICCRA` (production) is merge-only from `aiccra-staging`. Direct commits to production are forbidden.
+3. **Backups** — The daily MySQL → S3 backup job MUST remain green; monitoring and alerting on failures is a constitutional requirement.
+4. **Environments** — Test (CIAT Palmira), Staging (in build-out), Production (AWS Virginia). New features MUST be validated in Test before reaching `aiccra-staging`.
+
+---
+
+## 8. Assumptions, Dependencies, & Constraints
+
+### 8.1 Assumptions
+
+- AICCRA-style programs (multi-cluster, donor-funded, results-based) are the primary product context.
+- The Phase model (POWB / UpKeep / AR) reflects how partner programs operate.
+- Stakeholders accept the "forward-only replication" rule for phased data.
+- Power BI / Microsoft Fabric and AWS (RDS, S3, Lambda, Bedrock) remain the primary analytics and AI substrates.
+- Apache Shiro + CGIAR Active Directory remain the identity backbone.
+
+### 8.2 External dependencies
+
+| Dependency | Purpose | Risk class |
+|---|---|---|
+| CGIAR Active Directory | Authentication | Hard |
+| CLARISA | Reference data (institutions, geography, taxonomy) | Hard |
+| CGSpace | Open-access deposit and DOI metadata | Soft |
+| Power BI / Microsoft Fabric | Results BI + Process Monitoring dashboards | Hard |
+| AWS RDS (MySQL) | System of record | Hard |
+| AWS S3 | Backups, document storage | Hard |
+| AWS Lambda | AI/automation jobs | Soft |
+| AWS Bedrock (Claude, Titan) | Chatbot, RAG, embeddings | Soft |
+| Amazon OpenSearch | Vector index for Reports Generator | Soft |
+| Jenkins (PRMS automation) | CI/CD | Hard |
+| Freshservice | Support tickets | Soft |
+| Slack | Build notifications | Soft |
+| GlobalProtect VPN (production) / FortiClient (testing) | Network access | Hard |
+
+### 8.3 Constitutional constraints
+
+- **Tech stack** — Java + Struts 2 + Hibernate + Spring (REST) + FreeMarker + Tomcat 9 + MySQL. Java versions: 8 and 17 branches coexist; choose the run script per branch.
+- **Multi-module Maven** — `marlo-parent` aggregates `marlo-utils`, `marlo-core`, `marlo-data`, `marlo-web`. No new top-level module without a constitutional update.
+- **Web framework boundary** — `.do` (Struts) for internal flows; `/api/*` (Spring MVC) for REST. JSON via Struts is *punctual* and limited to existing patterns (per `AGENTS.md`).
+- **Phased persistence** — Changes that touch `ManagerImpl` save logic MUST preserve the recursive replication contract (`reports/ai-context/persistence-replication-managerimpl.md`).
+- **Code style** — 2-space indent, 120 char line limit, braces on same line, mandatory blocks for `if/while/for/do`, max file length 3500 lines (Checkstyle).
+- **License** — GNU GPL.
+
+---
+
+## 9. Open Questions
+
+These are the live, unresolved questions the constitution cannot answer alone. They MUST be resolved (or explicitly deferred) by an `epic` spec before they block product evolution.
+
+1. **Java 8 → Java 17 cutover** — When does the AICCRA production line switch fully off Java 8? Today both run scripts coexist (`scripts/run-marlo-java8.sh`, `scripts/run-marlo-java17.sh`). Modernization timeline TBD.
+2. **Frontend modernization** — FreeMarker + jQuery + Bootstrap is the current UI stack. A move toward server-rendered components with progressive enhancement (or partial React islands) has been discussed but not committed. Constitutional default remains FTL + macros.
+3. **Public REST API surface** — `/api/*` is currently used by trusted integrations. A formal external partner API (rate-limited, versioned beyond v2, OAuth2) is not yet committed.
+4. **Staging environment parity** — Staging is "currently being implemented." Until it mirrors production, hot fixes still validate against Test (CIAT Palmira). Define and ratify the parity contract.
+5. **Tenant onboarding playbook** — Onboarding a new Program/Platform is "controlled" today. A repeatable, scripted procedure (and the migration of seed data) would unlock the "MARLO as a Service" promise. Should live as an `epic` spec.
+6. **AI services governance** — Citations and grounding are required, but a formal evaluation harness for hallucination rate and SLA on AI services is not yet in place.
+7. **Legacy modules retirement** — `powb2019`, `annualReport2018`, and Pentaho/iText components are flagged for semi-annual review. Retire-or-keep decisions need explicit per-module specs.
+8. **Per-program visual identity** — Specificities and `custom/*.properties` give per-program text and feature toggles, but the depth of *visual* customization (logo, palette, components) per Global Unit is not yet fully documented. See `docs/system-design/design.md` §12.
+
+---
+
+## 10. Document map
+
+- **PRD (this document)** — Why MARLO exists and what success looks like.
+- `docs/system-design/design.md` — UI/UX system blueprint (FTL composition, macros, navigation, design tokens, accessibility).
+- `docs/detailed-design/detailed-design.md` — Technical blueprint (modules, data model, API surface, security, observability, testing).
+- `docs/specs/general-setup/` — Methodology templates for module specs (`requirements.md`, `design.md`, `task.md`).
+- `docs/specs/domain/<module>/` — Module-level SDD specs (e.g., `domain/projects/`, `domain/deliverables/`, `domain/innovations/`, `domain/oicrs/`, `domain/powb/`, `domain/annual-report/`, `domain/qa/`, `domain/admin/`, `domain/auth/`, `domain/bi/`, `domain/ai-services/`).
+- `docs/specs/enhancement/<feature>/` — Cross-cutting feature enhancements that don't belong to a single domain.
+- `docs/specs/bugfix/<slug>/` — Bug-driven specs requiring a structured trace.
+- `docs/specs/epic/<name>/` — Multi-spec initiatives (e.g., `epic/java-17-cutover/`, `epic/tenant-onboarding/`).
+- `reports/ai-context/*` — Operational runbooks for routing, validation, persistence, composition. Treat these as authoritative companion docs for module work.
+- `AGENTS.md` — Repo-level operational guidance for AI agents (style, file headers, specificity workflow, run scripts).

--- a/docs/specs/general-setup/design.md
+++ b/docs/specs/general-setup/design.md
@@ -1,0 +1,235 @@
+# MARLO — Design Spec Template
+
+**Purpose:** This file defines the *format and conventions* for `design.md` inside any module spec under `docs/specs/`. It is a methodology template, not a feature design.
+
+**Pairs with:** `requirements.md` and `task.md` in the same spec folder.
+
+---
+
+## Front matter (top of every `design.md`)
+
+```
+# <Module / Feature / Bug> — Design
+
+**Spec ID:** <same as requirements.md>
+**Status:** Draft | In Review | Approved | Implemented | Superseded
+**Owner:** <name / team>
+**Last Updated:** YYYY-MM-DD
+**Implements requirements:** list of requirement IDs covered.
+**Touches modules:** marlo-web, marlo-data, marlo-core, marlo-utils (as applicable).
+```
+
+---
+
+## Required structure
+
+A `design.md` MUST follow this section order. Empty sections MUST stay present with a "Not applicable" justification.
+
+1. **Architecture Summary** — short paragraph + simple diagram (ASCII or mermaid).
+2. **Module Footprint** — exact files / packages that will be added or changed, by Maven module.
+3. **Data Model Changes** — new entities, new columns, FK changes, indices, enums; the Flyway migration plan.
+4. **API / Action Surface** — new Struts actions, REST endpoints, JSON endpoints (only if pre-existing pattern).
+5. **Frontend Composition** — FTL views, macros, includes/imports, JS modules, expandable-block pattern usage.
+6. **Persistence & Phase Replication Plan** — explicit save and delete propagation strategy.
+7. **Validation & Save Pipeline** — interceptor stack, Action.validate(), Validator class, error surfaces.
+8. **Permissions & Edit Gates** — which interceptors / `canEdit*` checks apply.
+9. **Specificity / Feature-Flag Strategy** — if this is conditional, the `parameters` + `custom_parameters` plan.
+10. **Integration Points** — CLARISA, CGSpace, BI pipeline, AI services, S3, Pusher, etc.
+11. **Observability** — logs, metrics, audit columns, dashboards.
+12. **Performance & Scalability** — expected load, query patterns, indexing, caching.
+13. **Security Considerations** — authentication, authorization, sensitive data handling.
+14. **Backwards Compatibility & Rollout** — migrations, dual-running, feature-flag rollout plan, rollback path.
+15. **Decision Records** — the design choices made (ADR-style mini-entries).
+16. **Open Risks** — risks that survive into implementation.
+
+---
+
+## Module Footprint section format
+
+```
+## Module Footprint
+
+### marlo-web
+- New: action/projects/innovations/InnovationWizardAction.java
+- New: action/projects/innovations/InnovationWizardValidator.java
+- New: webapp/WEB-INF/crp/views/projects/innovations/innovationWizard.ftl
+- Modified: resources/struts-projects.xml (new <action> mapping)
+- Modified: resources/global.properties (i18n keys)
+
+### marlo-data
+- New: data/manager/ProjectInnovationWizardManager.java
+- New: data/manager/impl/ProjectInnovationWizardManagerImpl.java
+- New: data/dao/ProjectInnovationWizardDAO.java
+- New: data/dao/mysql/MySQLProjectInnovationWizardDAO.java
+- Modified: data/model/ProjectInnovation.java (new column)
+- Modified: config/APConstants.java (new specificity key)
+
+### marlo-core / marlo-utils
+- Not applicable.
+```
+
+---
+
+## Data Model Changes section format
+
+Always include the migration filename, target tables, and a copy of the migration body.
+
+```
+## Data Model Changes
+
+### Migration
+File: marlo-web/src/main/resources/database/migrations/V2_6_1_20260501_1030__InnovationScalingReadinessStep.sql
+
+```sql
+ALTER TABLE project_innovation
+  ADD COLUMN scaling_readiness_step TINYINT NULL AFTER scaling_readiness_level;
+
+CREATE INDEX idx_proj_innov_scaling_step ON project_innovation (scaling_readiness_step);
+```
+
+### Entity changes
+- `ProjectInnovation.java`: add `private Integer scalingReadinessStep;` with getter/setter and JPA mapping.
+
+### Indices, FKs, enums
+- New index: `idx_proj_innov_scaling_step`.
+- No new FKs.
+- No new enums.
+
+### Backfill / data migration
+- Not required (NULL default).
+```
+
+---
+
+## API / Action Surface section format
+
+```
+## API / Action Surface
+
+### Struts actions (.do)
+| Route | Action class | Stack | View result |
+|---|---|---|---|
+| /projects/{crp}/innovationWizard | InnovationWizardAction | editProjectListStack + editInnovation | /WEB-INF/crp/views/projects/innovations/innovationWizard.ftl |
+
+### Spring MVC REST
+- Not applicable.
+
+### Existing JSON endpoints
+- Not applicable. (Per AGENTS.md: do not introduce new JSON paths unless an existing pattern requires it.)
+```
+
+---
+
+## Persistence & Phase Replication Plan section format
+
+```
+## Persistence & Phase Replication Plan
+
+Pattern: standard MARLO ManagerImpl recursive replication
+(see reports/ai-context/persistence-replication-managerimpl.md).
+
+### Save flow
+1. ProjectInnovationWizardManagerImpl.save(...) persists current entity.
+2. Read currentPhase = phaseDao.find(...).
+3. If currentPhase is PLANNING and currentPhase.getNext() != null,
+   call addInnovationWizardPhase(...) for next phase, then recurse.
+4. If currentPhase is REPORTING, replicate to currentPhase.getNext().getNext()
+   (UpKeep) and recurse.
+5. Filter target phases for duplicates before insert.
+
+### Delete flow
+- Mirror save flow with deleteInnovationWizardPhase(...).
+- Maintain parity: if save propagates to phase X, delete propagates to phase X.
+
+### Section-specific skip rules
+- Not applicable. (No "publication-like" exclusions for this entity.)
+
+### Tests
+- New unit tests for both save and delete propagation chains.
+```
+
+---
+
+## Validation & Save Pipeline section format
+
+```
+## Validation & Save Pipeline
+
+- Interceptor stack: editProjectListStack + editInnovation (see struts-projects.xml).
+- Action.validate(): guarded with `if (save) { ... }`.
+- Validator class: `InnovationWizardValidator` extending `BaseValidator`.
+- On invalid: action populates `invalidFields` and action errors;
+  view re-renders with field-level + page-level messages.
+- On valid: ManagerImpl save chain runs (see Persistence section).
+```
+
+---
+
+## Permissions & Edit Gates section format
+
+```
+## Permissions & Edit Gates
+
+- Interceptors:
+  - `requireUser` (auth)
+  - `validCrp` (CRP scope)
+  - `editProjectsStack` base
+  - `editInnovation` (per-innovation edit gate)
+- Required role(s): Cluster Coordinator (write), QA Reviewer (read+comment).
+- REST: not applicable.
+```
+
+---
+
+## Specificity / Feature-Flag Strategy section format
+
+If conditional, follow the `AGENTS.md` specificity workflow exactly:
+
+```
+## Specificity / Feature-Flag Strategy
+
+- Specificity key: `innovation_scaling_readiness_wizard_enabled`
+- APConstants constant: `INNOVATION_SCALING_READINESS_WIZARD_ENABLED`
+  - Added in marlo-data/.../APConstants.java
+  - Added in marlo-web/.../APConstants.java
+- Migration: V2_6_1_20260501_1031__SpecInnovationScalingReadinessWizard.sql
+  - INSERT into parameters for global_unit_type_id 1, 3, 4 (CRP, Platform, Center).
+  - INSERT into custom_parameters for AICCRA (global_unit_id = <id>) with value = 'true'.
+- Backend gating: `if (this.hasSpecificities(APConstants.INNOVATION_SCALING_READINESS_WIZARD_ENABLED))`.
+- Frontend gating: `[#if action.hasSpecificities('innovation_scaling_readiness_wizard_enabled')]`.
+```
+
+If not conditional, write "Not applicable — feature ships unconditionally for all Global Units."
+
+---
+
+## Decision Records section format
+
+Each decision is a self-contained mini-ADR. Append-only.
+
+```
+## Decision Records
+
+### ADR-DOMAIN-INNOVATIONS-002-1 — 4-step wizard layout
+- Decision: Adopt a 4-step layout grouping levels {0–2, 3–5, 6–7, 8–9}.
+- Rationale: User testing showed 9-step layout felt hostile.
+- Alternatives considered: Single accordion, 9-step linear wizard.
+- Status: Accepted.
+
+### ADR-DOMAIN-INNOVATIONS-002-2 — Reuse expandable-block pattern
+- Decision: Render evidence list inside each step using the hidden-template pattern.
+- Rationale: Consistency with the rest of MARLO.
+- Status: Accepted.
+```
+
+---
+
+## Open Risks section format
+
+```
+## Open Risks
+- Risk: phase replication interaction with publication-class innovations is unclear.
+  Mitigation: review publication path before merge; add explicit test.
+- Risk: BI pipeline expects scaling_readiness_level only.
+  Mitigation: coordinate with BI team to add scaling_readiness_step in next Bronze refresh.
+```

--- a/docs/specs/general-setup/requirements.md
+++ b/docs/specs/general-setup/requirements.md
@@ -1,0 +1,180 @@
+# MARLO — Requirements Spec Template
+
+**Purpose:** This file defines the *format and conventions* for `requirements.md` inside any module spec under `docs/specs/`. It is a methodology template, not a feature spec.
+
+**Where to place a new module spec:**
+
+- `docs/specs/domain/<module>/` — for a domain area (e.g., `domain/deliverables/`, `domain/innovations/`).
+- `docs/specs/enhancement/<feature>/` — for a cross-cutting enhancement.
+- `docs/specs/bugfix/<slug>/` — for a structured bug-driven spec.
+- `docs/specs/epic/<name>/` — for a multi-spec initiative (e.g., `epic/java-17-cutover/`).
+
+Every spec folder MUST contain three files:
+
+- `requirements.md` (this template).
+- `design.md` (see `docs/specs/general-setup/design.md`).
+- `task.md` (see `docs/specs/general-setup/task.md`).
+
+---
+
+## Front matter (top of every `requirements.md`)
+
+```
+# <Module / Feature / Bug> — Requirements
+
+**Spec ID:** <DOMAIN-DELIVERABLES-001 | ENH-DARK-MODE-001 | BUG-PORTFOLIO-SAVE-001 | EPIC-JAVA17-CUTOVER>
+**Status:** Draft | In Review | Approved | Implemented | Superseded
+**Owner:** <name / team>
+**Reviewers:** <PMU lead, QA lead, Tech lead, etc.>
+**Last Updated:** YYYY-MM-DD
+**Related PRD sections:** docs/prd.md §<n>
+**Related System Design sections:** docs/system-design/design.md §<n>
+**Related Detailed Design sections:** docs/detailed-design/detailed-design.md §<n>
+**Companion ai-context docs:** reports/ai-context/<file>.md (when applicable)
+```
+
+---
+
+## Required structure
+
+A `requirements.md` MUST follow this section order. Empty sections MUST still be present with a "Not applicable" justification.
+
+1. **Overview** — one paragraph: what this spec is and why it exists now.
+2. **Problem Statement** — the user / operational pain in plain language. Cite the PRD problem area it addresses.
+3. **In-Scope Requirements** — numbered functional and non-functional requirements (§ Numbering & Writing rules below).
+4. **Out-of-Scope** — explicit list of what this spec does NOT cover.
+5. **Personas Affected** — which PRD personas (cluster coordinator, QA reviewer, PMU, admin, etc.) are affected and how.
+6. **Acceptance Criteria** — testable rules per requirement (Given/When/Then or equivalent).
+7. **Constitutional Compliance Checklist** — confirm each constitutional rule is honored or call out a deliberate deviation.
+8. **Open Questions** — questions that block design / implementation.
+9. **Decision Log** — append-only list of `YYYY-MM-DD — decision — rationale`.
+
+---
+
+## Requirement numbering
+
+Use a stable prefix per spec, then category, then sequence:
+
+```
+<SPEC_PREFIX>-FN-001   Functional requirement
+<SPEC_PREFIX>-NF-001   Non-functional requirement
+<SPEC_PREFIX>-DA-001   Data / persistence requirement
+<SPEC_PREFIX>-UI-001   UI / UX requirement
+<SPEC_PREFIX>-API-001  API / integration requirement
+<SPEC_PREFIX>-SEC-001  Security / authorization requirement
+<SPEC_PREFIX>-OPS-001  Operations / observability requirement
+<SPEC_PREFIX>-MIG-001  Migration / data-cutover requirement
+```
+
+Numbers are append-only. Removed requirements MUST be marked `(deprecated)` and kept in place to preserve traceability.
+
+---
+
+## Writing rules
+
+1. **Imperative voice.** "The system MUST …", "The Cluster Coordinator MUST be able to …".
+2. **One requirement per bullet.** Compound requirements split into multiple numbered items.
+3. **Testable.** Every requirement must be verifiable by a test, an inspection, or a UI walkthrough.
+4. **Cite the source.** When a requirement comes from the PRD, an ai-context doc, a Jira ticket, or a Freshservice ticket, cite it inline (`(see docs/prd.md §6.2)`).
+5. **No solutions in requirements.** Implementation choices belong in `design.md`.
+6. **English only.** Per `AGENTS.md`. User-facing strings reference i18n keys, not literal text.
+7. **Honor constitutional constraints.** Phased replication, specificity flow, save validation pattern, interceptor stacks, GPL header, Checkstyle, code style — all are non-negotiable unless an explicit, justified deviation is recorded in the Decision Log.
+
+---
+
+## Acceptance-criteria style
+
+Use Given/When/Then or numbered behavior assertions. Reference the requirement IDs:
+
+```
+AC for FN-001:
+- Given the user is an authenticated Cluster Coordinator with edit rights to cluster X,
+- When they save the Project Description form with a missing required field,
+- Then the page MUST re-render with the field-level error and the page-level message banner,
+- And the data MUST NOT be persisted,
+- And the audit log MUST NOT record a write.
+```
+
+---
+
+## Constitutional compliance checklist (copy-paste into every requirements.md)
+
+```
+- [ ] Phase replication: covered in design.md with explicit save and delete paths.
+- [ ] Save validation: Action.validate() + Validator + interceptor stack identified.
+- [ ] Permissions: every new action declares its interceptor stack.
+- [ ] Specificity: feature flag added through parameters + custom_parameters when conditional.
+- [ ] Migrations: every schema change ships as a Flyway migration with the V<...>__<Description>.sql naming.
+- [ ] i18n: no hardcoded user-facing strings; keys added to global.properties (and custom/*.properties when program-specific).
+- [ ] License header: every new Java file carries the GPL header from AGENTS.md.
+- [ ] Code style: Checkstyle passes; 2-space indent; 120 char line limit.
+- [ ] REST: any new /api/* endpoint uses Spring MVC, DTOs, Springdoc OpenAPI, and the rest/errors handlers.
+- [ ] Audit: auditable changes integrate with IAuditLog / HibernateAuditLogListener.
+- [ ] Dependency floors (post-Jan 2026 SETI baseline) preserved.
+- [ ] Branching: feature branch created from aiccra-staging; merge target is aiccra-staging; production AICCRA receives merges only.
+```
+
+---
+
+## Sample `requirements.md` skeleton (copy when starting a new spec)
+
+```
+# Innovations — Scaling Readiness Wizard — Requirements
+
+**Spec ID:** DOMAIN-INNOVATIONS-002
+**Status:** Draft
+**Owner:** Innovations team
+**Reviewers:** PMU lead, QA lead
+**Last Updated:** 2026-04-30
+**Related PRD sections:** docs/prd.md §6.1, §6.3
+**Related System Design sections:** docs/system-design/design.md §3, §6.3
+**Related Detailed Design sections:** docs/detailed-design/detailed-design.md §3, §5.1
+**Companion ai-context docs:** reports/ai-context/save-validation-matrix.md
+
+## 1. Overview
+...
+
+## 2. Problem Statement
+...
+
+## 3. In-Scope Requirements
+
+### Functional
+- DOMAIN-INNOVATIONS-002-FN-001 — The system MUST present a stepwise wizard for entering Scaling Readiness levels 0..9.
+- DOMAIN-INNOVATIONS-002-FN-002 — ...
+
+### Non-Functional
+- DOMAIN-INNOVATIONS-002-NF-001 — Wizard initial load p95 ≤ 1.5s on a warm Tomcat.
+
+### Data
+- DOMAIN-INNOVATIONS-002-DA-001 — A new column innovation.scaling_readiness_step (TINYINT NULL) MUST be added via Flyway migration ...
+
+### UI
+- DOMAIN-INNOVATIONS-002-UI-001 — The wizard MUST render via expandable blocks per the pattern in EXPANDABLE_BLOCKS_AGENT_INSTRUCTIONS.md.
+
+### Security
+- DOMAIN-INNOVATIONS-002-SEC-001 — The wizard route MUST be gated by canEditProject + editInnovation.
+
+## 4. Out-of-Scope
+- Public REST API for innovations write (covered separately).
+- Mobile-optimized layout (light theme only, desktop-first).
+
+## 5. Personas Affected
+- Cluster Coordinator (primary).
+- QA Reviewer (review path).
+- PMU (BI rollup).
+
+## 6. Acceptance Criteria
+...
+
+## 7. Constitutional Compliance Checklist
+- [x] Phase replication: covered in design.md (planning + reporting paths).
+- [x] Save validation: ProjectInnovationAction.validate() + ProjectInnovationValidator.
+- ...
+
+## 8. Open Questions
+- Should partial wizard progress autosave to draft?
+
+## 9. Decision Log
+- 2026-04-30 — Adopt a 4-step wizard (vs 9 steps) — Rationale: cluster coordinators reported the 9-step version felt hostile in user testing.
+```

--- a/docs/specs/general-setup/task.md
+++ b/docs/specs/general-setup/task.md
@@ -1,0 +1,220 @@
+# MARLO — Task Spec Template
+
+**Purpose:** This file defines the *format and conventions* for `task.md` inside any module spec under `docs/specs/`. It is the executable plan that translates an approved `design.md` into ordered, testable steps.
+
+**Pairs with:** `requirements.md` and `design.md` in the same spec folder.
+
+---
+
+## Front matter (top of every `task.md`)
+
+```
+# <Module / Feature / Bug> — Tasks
+
+**Spec ID:** <same as requirements.md and design.md>
+**Status:** Draft | Ready | In Progress | Done | Superseded
+**Owner:** <name / team>
+**Last Updated:** YYYY-MM-DD
+**Implements design:** docs/specs/<area>/<slug>/design.md
+**Branching:** feature branch from aiccra-staging, named aiccra-<slug-or-id>.
+**Target merge:** aiccra-staging (then promoted to AICCRA per release process).
+```
+
+---
+
+## Required structure
+
+A `task.md` MUST follow this section order. Empty sections MUST stay present with a "Not applicable" justification.
+
+1. **Execution Context** — environment, tools, run script (`scripts/run-marlo-java8.sh` or `run-marlo-java17.sh`), Spring profile.
+2. **Pre-flight Checklist** — confirm `requirements.md` and `design.md` are approved; pull latest `aiccra-staging`; create feature branch.
+3. **Task List** — ordered, atomic steps with IDs, dependencies, acceptance, and verification.
+4. **Dependency Graph** — visual or list form showing task ordering.
+5. **Testing Plan** — explicit unit, integration, regression, and manual testing per task or per group.
+6. **Operational Steps** — migration deploy, BI / AI service coordination, configuration changes, env-var changes.
+7. **Rollback Plan** — how to undo if production verification fails.
+8. **Definition of Done** — criteria for marking the spec Done.
+
+---
+
+## Task ID format
+
+Use the spec prefix + `T` + zero-padded sequence:
+
+```
+DOMAIN-INNOVATIONS-002-T01  Create migration for new column
+DOMAIN-INNOVATIONS-002-T02  Add APConstants entries (both modules)
+DOMAIN-INNOVATIONS-002-T03  Implement DAO + Manager + ManagerImpl
+DOMAIN-INNOVATIONS-002-T04  Implement Validator
+DOMAIN-INNOVATIONS-002-T05  Implement Action
+DOMAIN-INNOVATIONS-002-T06  Wire Struts mapping and interceptors
+DOMAIN-INNOVATIONS-002-T07  Implement FTL view + JS
+DOMAIN-INNOVATIONS-002-T08  i18n keys
+DOMAIN-INNOVATIONS-002-T09  Phase replication tests
+DOMAIN-INNOVATIONS-002-T10  Specificity migration + custom_parameters
+DOMAIN-INNOVATIONS-002-T11  Manual QA pass against acceptance criteria
+DOMAIN-INNOVATIONS-002-T12  Update relevant ai-context doc(s) if scope warrants
+```
+
+Numbers are append-only. Removed tasks are marked `(deprecated)` and kept.
+
+---
+
+## Task entry format
+
+Each task MUST include the seven fields below.
+
+```
+### DOMAIN-INNOVATIONS-002-T03 — Implement DAO + Manager + ManagerImpl
+
+- **Depends on:** T01, T02
+- **Module:** marlo-data
+- **Files touched:**
+  - data/dao/ProjectInnovationWizardDAO.java (new)
+  - data/dao/mysql/MySQLProjectInnovationWizardDAO.java (new)
+  - data/manager/ProjectInnovationWizardManager.java (new)
+  - data/manager/impl/ProjectInnovationWizardManagerImpl.java (new)
+- **Constitutional checks:**
+  - GPL header present in every new Java file.
+  - Layered pattern preserved (Manager → ManagerImpl → DAO → MySQLDAO).
+  - Phase replication implemented per persistence-replication-managerimpl.md.
+- **Tests:**
+  - Unit: save propagation Planning → all next phases.
+  - Unit: delete propagation Planning → all next phases.
+  - Unit: save propagation Reporting → UpKeep chain.
+- **Done when:**
+  - mvn checkstyle:check passes.
+  - Unit tests pass locally.
+  - No new Snyk critical findings on changed paths.
+- **Verification:**
+  - Manually invoke save through the action and confirm DB state in current and next phases.
+```
+
+---
+
+## Dependency Graph section format
+
+Use a simple list or a mermaid block. Keep it readable.
+
+```
+## Dependency Graph
+
+T01 (migration)
+  └── T02 (APConstants)
+        └── T03 (DAO + Manager)
+              ├── T04 (Validator)
+              │     └── T05 (Action)
+              │           └── T06 (Struts mapping)
+              │                 └── T07 (FTL + JS)
+              │                       └── T08 (i18n)
+              │                             └── T11 (manual QA)
+              └── T09 (replication tests)
+T10 (specificity migration) runs in parallel; gates T11 if rollout is conditional.
+T12 (ai-context doc updates) runs after T11.
+```
+
+---
+
+## Testing Plan section format
+
+Cover every layer relevant to the change.
+
+```
+## Testing Plan
+
+### Unit
+- ProjectInnovationWizardManagerImpl.save() Planning → all-next replication.
+- ProjectInnovationWizardManagerImpl.delete() Planning → all-next propagation.
+- Validator: required-field rules.
+
+### Integration
+- End-to-end save: HTTP POST → interceptor stack → action → manager → DB.
+- Confirm interceptor denial returns 403/redirect (not silent drop).
+
+### Regression (manual, QA team)
+- Project Description, Project Partners, Project Deliverable smoke (sections that share editProjectListStack).
+- Re-test save-validation matrix coverage of affected sections.
+
+### Non-functional
+- Load profile: simulate end-of-cycle peak (cluster coordinators submitting concurrently).
+
+### Accessibility
+- Keyboard navigation through wizard.
+- Screen reader announces step changes.
+```
+
+---
+
+## Operational Steps section format
+
+```
+## Operational Steps
+
+### Migration deploy
+- Flyway runs on Tomcat startup; confirm migration applied via flyway_schema_history.
+
+### Specificity rollout
+- Insert custom_parameters row for AICCRA (global_unit_id = <id>) with value = 'true'
+  *after* code is deployed, *not before*.
+
+### BI / AI coordination
+- Notify BI team: new column scaling_readiness_step lands in Bronze on next refresh.
+- Notify AI Reports Generator owner: new field available for narrative generation.
+
+### Backups
+- Production DB backup at S3 verified green within 24h prior to deploy.
+
+### Notifications
+- Slack #marlo-deploys on Jenkins success/failure (existing convention).
+```
+
+---
+
+## Rollback Plan section format
+
+```
+## Rollback Plan
+
+### Code
+- Revert merge commit on aiccra-staging.
+- Re-deploy previous artifact via Jenkins.
+
+### Data
+- Migration is additive (NULL column + index). No destructive rollback needed.
+- If rollback required, leave the column in place; feature flag (specificity) gates UI.
+
+### Specificity
+- Set custom_parameters.value = 'false' for affected global_unit_id to disable instantly.
+```
+
+---
+
+## Definition of Done section format
+
+```
+## Definition of Done
+
+- [ ] All acceptance criteria from requirements.md verified.
+- [ ] All constitutional compliance checklist items confirmed in PR.
+- [ ] mvn checkstyle:check passes.
+- [ ] SonarCloud: no new blockers / critical issues.
+- [ ] Snyk: no new critical findings.
+- [ ] QA test pass complete; defects closed or accepted with PMU sign-off.
+- [ ] Documentation updated:
+  - This task.md: every task marked done with verification notes.
+  - reports/ai-context/<file>.md updated if the change altered routing, validation, or replication contracts.
+- [ ] Merged to aiccra-staging.
+- [ ] Promoted to AICCRA via the release pipeline.
+- [ ] Deployment confirmed in production; backup green; QA dashboard confirms refresh latency.
+```
+
+---
+
+## Conventions reminders
+
+- **Branching:** never commit directly to `AICCRA`. Feature branches start from `aiccra-staging` and merge back into it. `aiccra-dev` is unstable and used only for integration experiments.
+- **Java version:** match the run script to the branch. If the branch contains `java17` / `java_17`, use `scripts/run-marlo-java17.sh`. Otherwise `scripts/run-marlo-java8.sh`.
+- **Local properties:** `marlo-${profile}.properties` files with credentials are gitignored; bootstrap from `marlo-test.properties`.
+- **Migration naming:** `V<major>_<minor>_<patch>_<YYYYMMDD>_<HHMM>__<Description>.sql`.
+- **Specificity naming:** snake_case key in `parameters`, UPPER_SNAKE_CASE constant in `APConstants`, identical string value.
+- **Hooks / pre-commit:** never bypass (`--no-verify`) without an explicit, documented reason; failing hooks are signal, not noise.

--- a/docs/system-design/design.md
+++ b/docs/system-design/design.md
@@ -1,0 +1,423 @@
+# MARLO — System Design (UI/UX Blueprint)
+
+**Status:** Living document. Version: 1.0 (Constitutional Baseline).
+**Owner:** IBD Team — Alliance of Bioversity International and CIAT.
+**Last Updated:** 2026-04-30.
+**Related:** [docs/prd.md](../prd.md), [docs/detailed-design/detailed-design.md](../detailed-design/detailed-design.md), [reports/ai-context/frontend-composition-map.md](../../reports/ai-context/frontend-composition-map.md).
+
+> This document defines MARLO's **UI/UX system**: how pages are composed, how forms behave, what visual and interaction primitives exist, and what the platform commits to in terms of consistency and accessibility. It is *not* a brand book; it is the rule set the codebase already follows and that future contributions must respect.
+
+---
+
+## 1. Product Experience Principles
+
+These are the experience principles that guide every UI decision in MARLO. They are derived from the platform's role as a multi-stakeholder, evidence-driven research-management tool.
+
+1. **Evidence over decoration.** The interface exists to capture and surface auditable data. Visual flourish must never obscure the data, the validation state, or the audit trail.
+2. **Phase-aware by default.** Every screen that touches phased data MUST make the active phase explicit and MUST signal when an action will replicate forward. Users should never lose data because they did not realize they were in a different phase.
+3. **Quality is part of the workflow.** QA feedback is a peer of the data, not a separate tool. Validation messages and reviewer comments live next to the field they describe.
+4. **Forgiving but auditable.** Save states are explicit (`Save` vs. `Save & Continue`). Drafts are common. The audit log captures what changed — the UI captures who is about to change it.
+5. **Multi-tenant clarity.** A user who works across more than one Global Unit (CRP / Platform / Center) MUST always see *which* one they are operating on, in the page chrome.
+6. **Accessibility as a constraint, not a feature.** WCAG 2.1 AA is the floor; new components MUST be keyboard-navigable and announce state changes.
+7. **Stable navigation.** Major menus are predictable across releases. Adding a section is a constitutional event; renaming or moving one is a notice-required change.
+8. **Internationalization-first.** No string lives in a `.ftl` or `.java` file. Every label, message, tooltip, and validation hint is i18n-keyed.
+9. **Progressive disclosure.** Long forms (POWB, AR, OICRs) use accordions, expandable blocks, and stepwise sections to keep cognitive load manageable.
+10. **Power BI is part of the experience.** When analytical context is more useful than a transactional view, link out to or embed the relevant dashboard rather than rebuild it inside the form.
+
+---
+
+## 2. Information Architecture
+
+MARLO's information architecture mirrors the lifecycle of a research program.
+
+### 2.1 Top-level zones
+
+1. **Home / Dashboard** — landing page per Global Unit, with active-phase summary and quick links to current cluster work.
+2. **Impact Pathway** — strategic structure: SLOs, IDOs, outcomes, cross-cutting issues, country collaborations.
+3. **POWB (Plan of Work and Budget)** — annual planning per cluster + program-level synthesis (Financial Plan, Management Governance, etc.).
+4. **Projects / Clusters** — operational layer: Description, Partners, Locations, Activities, Deliverables, Innovations, OICRs, Studies, Highlights, Case Studies.
+5. **Funding Sources** — donor and budget-line management, linked to deliverables and clusters.
+6. **Quality Assurance (QA)** — feedback queue, validation states, dashboards.
+7. **Annual Report (AR)** — narrative + indicator synthesis per cluster + program-wide.
+8. **Synthesis / Summaries** — cross-cutting aggregations (CRP indicators, MELIA, governance, communications).
+9. **Publications / Studies / TIP** — specialized output flows (publications, expected studies, technology innovation profile).
+10. **Business Intelligence (BI)** — dashboard hub (`/bi/{crp}/bi`).
+11. **AI** — entry points to text mining, report generator, chatbot.
+12. **Admin** — Program-level configuration: portfolios, partners, roles, locations, parameters, specificities, notifications, email tracking, bulk replication, system messages.
+13. **Super Admin** — System-level governance: Global Units, phases, system parameters.
+
+### 2.2 Multi-tenant scoping
+
+URLs are scoped by `{crp}` (the Global Unit acronym). Examples:
+
+- `/projects/{crp}/description.do`
+- `/powb/{crp}/financialPlan.do`
+- `/annualReport/{crp}/melia.do`
+- `/admin/{crp}/portfolioManagement.do`
+- `/bi/{crp}/bi.do`
+- `/api/v2/...` — Spring MVC REST (out of `.do` namespace).
+
+`{crp}` validation is enforced by interceptors (`validCrp`, `validSessionCrp`).
+
+### 2.3 Phase context
+
+Every phased screen renders the **active phase chip** in the page header (e.g., `POWB 2026`, `AR 2025`, `UpKeep 2026`). The chip exposes a phase switcher when the user has rights to view past phases (read-only) or work in future phases.
+
+---
+
+## 3. Primary User Flows
+
+### 3.1 Annual planning flow (Cluster Coordinator)
+
+1. Land on Home Dashboard → see active POWB phase chip and incomplete sections list.
+2. Open Project Description → fill required fields, save.
+3. Open Project Partners → add partner institutions (CLARISA-backed selector).
+4. Open Activities → register activities with timelines and partner ownership.
+5. Open Deliverables → add deliverables with metadata, expected dissemination, and Open Access intent.
+6. Open Innovations → register innovations with Scaling Readiness 0–9.
+7. Open OICRs → register outcome impact case reports with maturity classification.
+8. Submit cluster plan → status moves to *Awaiting QA*.
+
+### 3.2 Annual reporting flow (Cluster Coordinator)
+
+1. Phase chip shows AR 2025.
+2. Open Project Description (Reporting view) → confirm or update fields.
+3. Open Deliverable → upload the deliverable artifact / DOI / dissemination evidence.
+4. Open OICR → mark maturity, attach evidence.
+5. Open AR Synthesis sections (MELIA, Governance, Communications, Cross-Cutting).
+6. Submit → QA reviewers receive items in their queue.
+
+### 3.3 QA flow (QA Reviewer)
+
+1. Open QA queue → filter by cluster + section + status.
+2. Open item → review fields side-by-side with previous-phase values when available.
+3. Add structured feedback comments (one comment can be field-scoped).
+4. Mark item *Validated* / *Needs revision*.
+5. QA dashboard refreshes (≤ 30 minutes during active periods).
+
+### 3.4 PMU synthesis & report generation
+
+1. Open BI hub → cluster completeness dashboard.
+2. Use AI Reports Generator → produce a cluster-specific narrative grounded in MARLO data.
+3. Edit, validate, export the donor-ready report.
+
+### 3.5 Public consumption
+
+1. Public reader visits embedded dashboards (Power BI JS API).
+2. Drill-through links resolve to other public dashboards or to public-safe MARLO views.
+
+---
+
+## 4. Screen Inventory
+
+This is the *constitutional* set of top-level views. Each lives under `marlo-web/src/main/webapp/WEB-INF/crp/views/<area>/` (or `WEB-INF/global/...` for shared screens). Module specs may add screens, but renaming or removing a screen here is a constitutional event.
+
+### 4.1 Home
+
+- `home/dashboard.ftl` — landing page with active-phase summary.
+
+### 4.2 Impact Pathway
+
+- `impactPathway/outcomes.ftl`
+- `impactPathway/sloIndicators.ftl`
+- `impactPathway/programImpacts.ftl`
+- `impactPathway/crossCuttingDimensions.ftl`
+
+### 4.3 POWB
+
+- `powb/powb_financialPlan.ftl`
+- `powb/powb_managementGovernance.ftl`
+- `powb/powb_evidence.ftl`
+- `powb/powb_crossCuttingDimensions.ftl`
+- (legacy) `powb2019/*` — frozen, retained for historical compatibility.
+
+### 4.4 Projects / Clusters
+
+- `projects/projectDescription.ftl`
+- `projects/projectPartners.ftl`
+- `projects/projectLocations.ftl`
+- `projects/projectActivities.ftl`
+- `projects/projectDeliverable.ftl`
+- `projects/projectExpectedStudy.ftl`
+- `projects/projectInnovation.ftl`
+- `projects/projectHighLights.ftl`
+- `projects/projectCaseStudy.ftl`
+- `projects/projectBudgetByPartners.ftl`
+- `projects/projectBudgetByCoAs.ftl`
+- `projects/projectOutcomes.ftl`
+
+### 4.5 Funding Sources
+
+- `fundingSources/fundingSource.ftl`
+- `fundingSources/fundingSourcesList.ftl`
+- `fundingSources/fundingSourcesSummary.ftl`
+
+### 4.6 Quality Assurance
+
+- `qualityAssessment/qualityAssessmentList.ftl`
+- `qualityAssessment/qualityAssessmentDetail.ftl`
+
+### 4.7 Annual Report
+
+- `annualReport/annualReport_melia.ftl`
+- `annualReport/annualReport_governance.ftl`
+- `annualReport/annualReport_communications.ftl`
+- `annualReport/annualReport_crossCutting.ftl`
+- `annualReport/annualReport_evidence.ftl`
+- (legacy) `annualReport2018/*` — frozen.
+
+### 4.8 Synthesis & Summaries
+
+- `synthesis/*.ftl` (CRP-level synthesis)
+- `summaries/*.ftl` (predefined PDFs/exports)
+
+### 4.9 Studies / Publications / TIP
+
+- `studies/*.ftl`
+- `publications/*.ftl`
+- `tip/*.ftl`
+
+### 4.10 BI
+
+- `bi/biDashboard.ftl`
+
+### 4.11 AI
+
+- `ai/aiUserIdeas.ftl` (or analogous landing for AI services)
+
+### 4.12 Admin
+
+- `admin/portfoliosManagement.ftl`
+- `admin/timelineManagement.ftl`
+- `admin/partnersManagement.ftl`
+- `admin/usersManagement.ftl`
+- `admin/locationsManagement.ftl`
+- `admin/parametersManagement.ftl`
+- `admin/messagesManagement.ftl`
+- `admin/notificationsManagement.ftl`
+
+### 4.13 Super Admin
+
+- `superadmin/*.ftl` — phases, Global Units, cross-program parameters.
+
+---
+
+## 5. Navigation Model
+
+### 5.1 Shell layout
+
+The page shell is composed by global FTL fragments under `WEB-INF/global/pages/`:
+
+- `header.ftl` — brand, user chip, Global Unit selector, phase chip, language selector.
+- `main-menu.ftl` — top-level zone navigation (Home, Impact Pathway, POWB, Projects, Funding Sources, QA, AR, BI, AI, Admin).
+- `footer.ftl` — version, support email, license info, language switch.
+- `breadcrumb.ftl` — context trail (e.g., `Admin > Portfolios > Cluster A`).
+- `messages.ftl` / `generalMessages.ftl` — global success/info/error banner.
+
+Module-specific submenus live alongside the views (e.g., `submenu-powb.ftl`, `menu-admin.ftl`).
+
+### 5.2 Composition rules (from `frontend-composition-map.md`)
+
+- **Includes (`[#include]`)** compose the page from layout fragments.
+- **Imports (`[#import ... as alias]`)** bring in macro libraries.
+- **Macros** are the canonical reusable UI primitives. New raw HTML inside a section MUST first try a macro from `forms.ftl`, `homeDashboard.ftl`, `deliverableMacros.ftl`, `innovationTemplates.ftl`, `studiesTemplates.ftl`, `ARMacros.ftl`, etc.
+- **Expandable blocks** follow the *hidden template + indexed fields* pattern documented in `EXPANDABLE_BLOCKS_AGENT_INSTRUCTIONS.md`.
+
+### 5.3 Linking conventions
+
+- Internal navigation uses Struts action URLs (`/{namespace}/{crp}/{action}.do`).
+- AJAX/JSON is reserved for explicitly approved patterns (see `AGENTS.md`).
+- BI deep-links use Power BI JS API embedding.
+
+---
+
+## 6. Layout Patterns
+
+### 6.1 Standard form page
+
+```
++---------------------------------------------------------------+
+| header.ftl                                                    |
++---------------------------------------------------------------+
+| breadcrumb.ftl                                                |
++---------------------------------------------------------------+
+| submenu-<area>.ftl  (left or top, area-dependent)             |
++---------------------------------------------------------------+
+| messages-<area>.ftl                                           |
++---------------------------------------------------------------+
+|                                                               |
+|  Section title + active-phase chip + permission state         |
+|                                                               |
+|  [section content via macros + expandable blocks]             |
+|                                                               |
+|  buttons-<area>.ftl: [Cancel] [Save] [Save & Continue]        |
++---------------------------------------------------------------+
+| footer.ftl                                                    |
++---------------------------------------------------------------+
+```
+
+### 6.2 List + detail
+
+Used in QA queues, Funding Sources list, Projects list. Left column = filterable list (DataTables). Right column or detail page = read-only summary or edit form.
+
+### 6.3 Expandable block list
+
+Used for repeated entries (deliverables, innovations, partners, OICRs, comments). One hidden template block + a visible list. JS clones the template, reindexes fields (`items[i].id`, `items[i].name`), and posts a single form. Server reconciles posted IDs against persisted records (delete missing IDs, update existing, create new).
+
+### 6.4 Wizard / step layout
+
+Used for AR/POWB synthesis where the user navigates many sub-sections. The submenu plays the wizard role — each step is a dedicated `.ftl`, but state is shared via the underlying entity (e.g., `powbSynthesis`, `reportSynthesis`).
+
+### 6.5 Dashboard / BI page
+
+Embedded Power BI report inside a host FTL view (`bi/biDashboard.ftl`), parameterized via `BiParameters`.
+
+---
+
+## 7. Design Tokens
+
+MARLO does not have a formal design-token system today. Tokens are de facto encoded across the global stylesheets. The constitutional baseline below documents what *exists*; module specs MUST consume these and not introduce parallel palettes.
+
+### 7.1 Source files
+
+- `marlo-web/src/main/webapp/global/css/global.css` — base typography, layout, brand color usage.
+- `global/css/custom.bootstrap.css` — Bootstrap overrides.
+- `global/css/custom-forms-min.css` — form input visuals.
+- `global/css/customDataTable.css`, `customDataTable-flat.css` — tables.
+- `global/css/customChosen.css`, `customInputsFlat.css`, `customLogin.css`, `customTrumbowyg.css`, `custom.pickadate.css` — third-party widget skins.
+- `global/css/global-center.css` — centers (CGIAR center) layout overrides.
+- `global/css/jquery-ui.custom.css`, `glossary.css`, `legalInformation.css`, `403.css` / `404.css` / `500.css` — auxiliary screens.
+
+### 7.2 Token categories
+
+| Category | Where it lives today | Constitutional rule |
+|---|---|---|
+| Brand color (primary CGIAR/AICCRA accent) | `global.css` | One primary accent per Global Unit; per-program overrides via `custom/*.css` references. |
+| Neutrals (grays / borders) | `global.css` + Bootstrap defaults | Reuse existing scale; do not introduce new ad-hoc grays. |
+| Typography | `global.css` (Helvetica / Arial fallback stack, base size ~14px) | Headings driven by Bootstrap heading classes; do not introduce new heading scales without a constitutional update. |
+| Spacing | Bootstrap grid (`col-md-*`) + utility classes | Use Bootstrap spacing utilities; avoid inline pixel values. |
+| Form controls | `custom-forms-min.css` + `forms.ftl` macros | All inputs MUST go through the `forms.ftl` macros. |
+| Tables | `customDataTable*.css` + DataTables configuration | All structured tables use DataTables; raw `<table>` is for trivial layout only. |
+| Status colors (success / warn / error / info) | Bootstrap alert / label classes | Reuse Bootstrap semantics; do not re-encode. |
+| Iconography | Font Awesome (`bower_components/components-font-awesome`) + flag-icons | Reuse existing icon sets. |
+
+### 7.3 Future token unification
+
+Token unification (a single CSS-variables manifest, or a SCSS-driven token file) is an *open gap* (see §13). Until then, do not refactor tokens incrementally — propose a dedicated `enhancement` spec.
+
+---
+
+## 8. Component Inventory
+
+The constitutional component inventory is defined by `forms.ftl` and the cross-cutting macros under `marlo-web/src/main/webapp/WEB-INF/global/macros/`.
+
+### 8.1 Form macros (`forms.ftl`)
+
+- `input` — single-line text input.
+- `textArea` — multi-line text input (often with Trumbowyg rich-text).
+- `select` — dropdown (Chosen / Bootstrap-Select backed).
+- `checkbox` — boolean control.
+- `radioButtonGroup` — grouped radio buttons.
+- `datepicker` — pickadate-backed.
+- (Specialized macros for indicators, milestones, geolocations are layered on top of these.)
+
+### 8.2 Cross-cutting macros
+
+- `homeDashboard.ftl` — dashboard widgets (deliverables list, OICR list, etc.).
+- `deliverableListTemplate.ftl`, `deliverableMacros.ftl` — deliverable rendering primitives.
+- `innovationTemplates.ftl` — innovation block rendering.
+- `studiesTemplates.ftl` — expected-study rendering.
+- `ARMacros.ftl` — Annual Report rendering primitives.
+- `usersPopup.ftl`, `allInstitutionsPopup.ftl`, `fundingSourcesPopup.ftl`, `rejectInstitutionPopup.ftl`, `institutionRequestMacro.ftl` — modal pickers.
+- `discardChangesPopup.ftl`, `draftMessage.ftl` — guardrails for unsaved-state UX.
+- `historyDiff.ftl`, `logHistory.ftl` — audit visualization.
+
+### 8.3 Patterns
+
+- **Auto-save** (`global/js/autoSave.js`) — long forms periodically autosave to draft state.
+- **Field validation** (`global/js/fieldsValidation.js`) — client-side validation surfaces errors before submit.
+- **Sortable lists** (`global/js/sortableList.js`) — for ordered collections.
+- **Expandable blocks** — see §6.3 and `EXPANDABLE_BLOCKS_AGENT_INSTRUCTIONS.md`.
+- **Cytoscape graphs** — `bower_components/cytoscape*` for impact-pathway visualization.
+- **Pusher** (`global/js/pusher-app.js`) — real-time notifications channel.
+- **Intro.js** — guided tours.
+
+### 8.4 Constitutional rule
+
+New UI patterns MUST first try to extend an existing macro before introducing a new component. New components MUST be added under `WEB-INF/global/macros/` with their own file and an entry under §8 of this document in the next constitution update.
+
+---
+
+## 9. Responsive Behavior
+
+MARLO targets desktop-first, with graceful degradation to tablet. Phone-sized screens are *not* a primary use case for data entry (this is an explicit product decision, given the density of MARLO forms).
+
+### 9.1 Breakpoints
+
+Bootstrap default breakpoints govern layout (`xs`, `sm`, `md`, `lg`). Most production pages target `md` and `lg`.
+
+### 9.2 Rules
+
+- Page chrome (header, menu, footer) collapses to a hamburger menu below `md`.
+- Long forms keep desktop column structure; below `md`, columns stack and DataTables become horizontally scrollable.
+- BI dashboards are NOT designed for `xs`; users on small screens are routed to the public Power BI URL.
+
+---
+
+## 10. Accessibility Expectations
+
+WCAG 2.1 AA is the constitutional floor.
+
+### 10.1 Mandatory rules
+
+1. Every `input`, `textArea`, `select`, `checkbox`, and `radioButtonGroup` macro renders an associated `<label>`.
+2. Color is never the sole indicator of state — use icon + text + color together (e.g., success = green check + "Validated").
+3. All interactive elements are keyboard-operable; tab order follows visual order.
+4. Modals trap focus and restore it on close.
+5. Form-level errors are announced via an alert region (`role="alert"`) tied to the page-level message banner.
+6. Field-level errors are tied to their input via `aria-describedby`.
+7. Tables convey row/column relationships via `<th scope>`.
+8. Non-decorative images (e.g., country flag icons in indicator lists) carry `alt` text.
+
+### 10.2 Audit cadence
+
+Accessibility regressions are caught during QA testing (see PRD §7). A formal automated audit (axe-core or Pa11y) is an open gap.
+
+---
+
+## 11. Dark Mode Behavior
+
+MARLO does NOT ship a dark theme today. The constitutional position is: **light theme only**.
+
+This is a deliberate constraint — adding dark mode is a non-trivial undertaking given the legacy CSS, third-party widget skins (Trumbowyg, Chosen, Pickadate, DataTables), and the tightly coupled stylesheets. Module specs MUST NOT introduce dark-only colors. A future `enhancement` spec under `docs/specs/enhancement/dark-mode/` would be required to change this.
+
+---
+
+## 12. Design Decisions
+
+| Decision | Rationale | Where it shows up |
+|---|---|---|
+| FTL + jQuery + Bootstrap as the UI stack | Long-running platform with deep institutional muscle memory; reliability beats novelty. | All `*.ftl` views, `global/js/*.js`. |
+| Forms-first information architecture | MARLO is data-collection software for research teams, not a content site. | Every operational view. |
+| Phase chip in the header | Phase awareness is the most common source of "I lost my data" regressions. | `header.ftl` + per-action context. |
+| Expandable blocks for repeated entries | Consistent CRUD pattern for partners, deliverables, comments, etc. | Admin + project sections; see `EXPANDABLE_BLOCKS_AGENT_INSTRUCTIONS.md`. |
+| `forms.ftl` as the single source of form macros | Avoids drift across modules. | Every form view. |
+| Embedded Power BI over reinventing dashboards | Leverages existing BI pipeline; respects the Bronze/Silver/Gold separation. | `bi/biDashboard.ftl`, public embed tool. |
+| Per-program text via `custom/*.properties` | Programs can rename / re-tone strings without forking. | i18n bundles. |
+| Per-program behavior via specificities | Feature flags scoped by Global Unit. | `parameters` + `custom_parameters` tables (see `AGENTS.md`). |
+| Discard-changes popup before navigating away | Long forms cannot afford accidental loss. | `discardChangesPopup.ftl`. |
+| Auto-save drafts | Reduces blast radius of session timeouts. | `global/js/autoSave.js`. |
+
+---
+
+## 13. Open Gaps / Open Questions
+
+1. **Design tokens are implicit.** No single source-of-truth file declares brand color, neutrals, spacing, typography. Refactoring tokens is deferred to a future `enhancement/design-tokens/` spec.
+2. **Component library has no Storybook / catalog.** Discoverability of macros depends on grep + file reading. A static catalog would help onboarding.
+3. **Per-program visual identity scope** — beyond strings, what visual customization is allowed per Global Unit (logo, palette)? Constitutional answer is "logo + minor accent only," but scope needs explicit ratification.
+4. **Accessibility automation.** No CI-integrated a11y testing today. Adding axe-core or Pa11y to QA is a candidate enhancement.
+5. **Dark mode.** Out of scope today; revisit if/when tokens are unified (#1).
+6. **Mobile-class data entry.** Out of scope today; revisit if/when MARLO grows a partner program with field-staff data entry needs.
+7. **Frontend modernization (FTL → React islands, etc.).** Not committed; tracked as PRD open question §9.2.
+8. **Real-time collaborative editing on the same form.** Not in scope; current architecture assumes one editor per cluster section at a time.
+9. **Print / export styling consistency.** Pentaho + iText handle exports today; visual parity with the on-screen UI is approximate. A formal export style guide would close the gap.

--- a/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/dao/PhaseDAO.java
+++ b/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/dao/PhaseDAO.java
@@ -73,6 +73,14 @@ public interface PhaseDAO {
   public Phase getActivePhase(long globalUnitId);
 
   /**
+   * This method gets a list of phases filtered by global unit ID
+   * 
+   * @param globalUnitId the global unit identifier
+   * @return a list of phases for the given global unit
+   */
+  public List<Phase> getPhasesByGlobalUnitId(long globalUnitId);
+
+  /**
    * This method saves the information of the given phase
    * 
    * @param phase - is the phase object with the new information to be added/updated.

--- a/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/dao/mysql/PhaseMySQLDAO.java
+++ b/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/dao/mysql/PhaseMySQLDAO.java
@@ -112,6 +112,13 @@ public class PhaseMySQLDAO extends AbstractMarloDAO<Phase, Long> implements Phas
     return phases.get(0);
   }
 
+  @Override
+  public List<Phase> getPhasesByGlobalUnitId(long globalUnitId) {
+    String query = "from " + Phase.class.getName() + " where global_unit_id = " + globalUnitId
+      + " order by startDate asc, id asc";
+    List<Phase> list = super.findAll(query);
+    return (list != null && list.size() > 0) ? list : null;
+  }
 
   @Override
   public Phase save(Phase phase) {

--- a/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/manager/PhaseManager.java
+++ b/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/manager/PhaseManager.java
@@ -70,6 +70,14 @@ public interface PhaseManager {
   public Phase getActivePhase(long globalUnitId);
 
   /**
+   * This method gets a list of phases filtered by global unit ID
+   * 
+   * @param globalUnitId the global unit identifier
+   * @return a list of phases for the given global unit
+   */
+  public List<Phase> getPhasesByGlobalUnitId(long globalUnitId);
+
+  /**
    * This method gets a phase object by a given phase identifier.
    * 
    * @param phaseID is the phase identifier.

--- a/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/manager/impl/PhaseManagerImpl.java
+++ b/marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/manager/impl/PhaseManagerImpl.java
@@ -78,6 +78,11 @@ public class PhaseManagerImpl implements PhaseManager {
   }
 
   @Override
+  public List<Phase> getPhasesByGlobalUnitId(long globalUnitId) {
+    return phaseDAO.getPhasesByGlobalUnitId(globalUnitId);
+  }
+
+  @Override
   public Phase getPhaseById(long phaseID) {
 
     return phaseDAO.find(phaseID);

--- a/marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/BaseAction.java
+++ b/marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/BaseAction.java
@@ -2206,9 +2206,7 @@ public class BaseAction extends ActionSupport implements Preparable, SessionAwar
       Map<Long, Phase> allPhases = null;
       if (this.getSession() != null && !this.getSession().isEmpty()) {
         if (!this.getSession().containsKey(APConstants.ALL_PHASES)) {
-          List<Phase> phases = this.phaseManager.findAll().stream()
-            .filter(c -> c.getCrp().getId().longValue() == this.getCrpID().longValue()).collect(Collectors.toList());
-          phases.sort((p1, p2) -> p1.getStartDate().compareTo(p2.getStartDate()));
+          List<Phase> phases = this.phaseManager.getPhasesByGlobalUnitId(this.getCrpID());
           Map<Long, Phase> allPhasesMap = new HashMap<>();
           for (Phase phase : phases) {
             allPhasesMap.put(phase.getId(), phase);
@@ -2291,9 +2289,7 @@ public class BaseAction extends ActionSupport implements Preparable, SessionAwar
       Map<Long, Phase> allPhases = null;
       if (session != null) {
         if (session.containsKey(APConstants.ALL_PHASES)) {
-          List<Phase> phases = this.phaseManager.findAll().stream()
-            .filter(c -> c.getCrp().getId().longValue() == this.getCrpID().longValue()).collect(Collectors.toList());
-          phases.sort((p1, p2) -> p1.getStartDate().compareTo(p2.getStartDate()));
+          List<Phase> phases = this.phaseManager.getPhasesByGlobalUnitId(this.getCrpID());
           Map<Long, Phase> allPhasesMap = new HashMap<>();
           for (Phase phase : phases) {
             allPhasesMap.put(phase.getId(), phase);
@@ -2369,9 +2365,7 @@ public class BaseAction extends ActionSupport implements Preparable, SessionAwar
    */
   public List<Phase> getAllCreatedPhases() {
 
-    List<Phase> phases = this.phaseManager.findAll().stream()
-      .filter(c -> c.getCrp().getId().longValue() == this.getCrpID().longValue()).collect(Collectors.toList());
-    phases.sort((p1, p2) -> p1.getStartDate().compareTo(p2.getStartDate()));
+    List<Phase> phases = this.phaseManager.getPhasesByGlobalUnitId(this.getCrpID());
     this.getSession().put(APConstants.PHASES, phases);
     return phases;
 
@@ -2385,9 +2379,7 @@ public class BaseAction extends ActionSupport implements Preparable, SessionAwar
   public Map<Long, Phase> getAllPhases() {
     if (this.getSession() != null) {
       if (!this.getSession().containsKey(APConstants.ALL_PHASES)) {
-        List<Phase> phases = this.phaseManager.findAll().stream()
-          .filter(c -> c.getCrp().getId().longValue() == this.getCrpID().longValue()).collect(Collectors.toList());
-        phases.sort((p1, p2) -> p1.getStartDate().compareTo(p2.getStartDate()));
+        List<Phase> phases = this.phaseManager.getPhasesByGlobalUnitId(this.getCrpID());
         Map<Long, Phase> allPhasesMap = new HashMap<>();
         for (Phase phase : phases) {
           allPhasesMap.put(phase.getId(), phase);
@@ -4845,10 +4837,8 @@ public class BaseAction extends ActionSupport implements Preparable, SessionAwar
     if (this.getSession().containsKey(APConstants.PHASES)) {
       return (List<Phase>) this.getSession().get(APConstants.PHASES);
     } else {
-      List<Phase> phases = this.phaseManager.findAll().stream().filter(
-        c -> c.getCrp().getId().longValue() == this.getCrpID().longValue() && c.getVisible() != null && c.getVisible())
-        .collect(Collectors.toList());
-      phases.sort((p1, p2) -> p1.getStartDate().compareTo(p2.getStartDate()));
+      List<Phase> phases = this.phaseManager.getPhasesByGlobalUnitId(this.getCrpID());
+      phases = phases.stream().filter(c -> c != null && c.getVisible() != null && c.getVisible()).collect(Collectors.toList());
       this.getSession().put(APConstants.PHASES, phases);
       return phases;
     }
@@ -4859,10 +4849,8 @@ public class BaseAction extends ActionSupport implements Preparable, SessionAwar
    */
   public List<Phase> getPhasesByCycles(List<String> reportCycles) {
     List<Phase> phasesFilter = new ArrayList<>();
-    List<Phase> phases = this.phaseManager.findAll().stream()
-      .filter(
-        c -> c.getCrp().getId().longValue() == this.getCrpID().longValue() && c.getVisible() != null && c.getVisible())
-      .collect(Collectors.toList());
+    List<Phase> phases = this.phaseManager.getPhasesByGlobalUnitId(this.getCrpID());
+    phases = phases.stream().filter(c -> c != null && c.getVisible() != null && c.getVisible()).collect(Collectors.toList());
     for (int i = 0; i < phases.size(); i++) {
       for (int j = 0; j < reportCycles.size(); j++) {
         if (phases.get(i).getDescription().equalsIgnoreCase(reportCycles.get(j))) {
@@ -4878,11 +4866,9 @@ public class BaseAction extends ActionSupport implements Preparable, SessionAwar
     if (this.getSession().containsKey(APConstants.PHASES_IMPACT)) {
       return (List<Phase>) this.getSession().get(APConstants.PHASES_IMPACT);
     } else {
-      List<Phase> phases = this.phaseManager
-        .findAll().stream().filter(c -> c.getCrp().getId().longValue() == this.getCrpID().longValue()
-          && c.getVisible() != null && c.getVisible() && c.getDescription().equals(APConstants.PLANNING))
-        .collect(Collectors.toList());
-      phases.sort((p1, p2) -> p1.getStartDate().compareTo(p2.getStartDate()));
+      List<Phase> phases = this.phaseManager.getPhasesByGlobalUnitId(this.getCrpID());
+      phases = phases.stream().filter(c -> c != null && c.getVisible() != null && c.getVisible()).collect(Collectors.toList());
+      phases = phases.stream().filter(c -> c.getDescription().equals(APConstants.PLANNING)).collect(Collectors.toList());
       this.getSession().put(APConstants.PHASES_IMPACT, phases);
       return phases;
     }
@@ -4893,11 +4879,9 @@ public class BaseAction extends ActionSupport implements Preparable, SessionAwar
     if (this.getSession().containsKey(APConstants.PHASES_IMPACT)) {
       phases = (List<Phase>) this.getSession().get(APConstants.PHASES_IMPACT);
     } else {
-      phases = this.phaseManager
-        .findAll().stream().filter(c -> c.getCrp().getId().longValue() == this.getCrpID().longValue()
-          && c.getVisible() != null && c.getVisible() && c.getDescription().equals(APConstants.PLANNING))
-        .collect(Collectors.toList());
-      phases.sort((p1, p2) -> new Integer(p1.getYear()).compareTo(new Integer(p2.getYear())));
+      phases = this.phaseManager.getPhasesByGlobalUnitId(this.getCrpID());
+      phases = phases.stream().filter(c -> c != null && c.getVisible() != null && c.getVisible()).collect(Collectors.toList());
+      phases = phases.stream().filter(c -> c.getDescription().equals(APConstants.PLANNING)).collect(Collectors.toList());
       this.getSession().put(APConstants.PHASES_IMPACT, phases);
     }
 
@@ -4917,10 +4901,8 @@ public class BaseAction extends ActionSupport implements Preparable, SessionAwar
     if (this.getSession().containsKey(APConstants.PHASES)) {
       phases = (List<Phase>) this.getSession().get(APConstants.PHASES);
     } else {
-      phases = this.phaseManager.findAll().stream().filter(
-        c -> c.getCrp().getId().longValue() == this.getCrpID().longValue() && c.getVisible() != null && c.getVisible())
-        .collect(Collectors.toList());
-      phases.sort((p1, p2) -> new Integer(p1.getYear()).compareTo(new Integer(p2.getYear())));
+      phases = this.phaseManager.getPhasesByGlobalUnitId(this.getCrpID());
+      phases = phases.stream().filter(c -> c != null && c.getVisible() != null && c.getVisible()).collect(Collectors.toList());
       this.getSession().put(APConstants.PHASES, phases);
     }
     GsonBuilder builder = new GsonBuilder();

--- a/reports/ai-context/frontend-composition-map.md
+++ b/reports/ai-context/frontend-composition-map.md
@@ -1,0 +1,58 @@
+# Frontend Composition Map
+
+## Scope
+This document maps how MARLO composes FTL pages through includes, imports, and macros/components.
+
+## Composition Rules
+1. `[#include]` composes page fragments (header, menu, footer, messages, submenus).
+2. `[#import ... as alias]` imports macro libraries and template components.
+3. Macro calls use aliases (`[@customForm.input ... /]`, `[@projectList.dashboardProjectsList ... /]`).
+4. Dynamic list blocks use template macros (`isTemplate=true`) hidden in DOM and cloned by JS.
+
+## Flow A: Home Dashboard (Projects)
+- Main view: `marlo-web/src/main/webapp/WEB-INF/crp/views/home/dashboard.ftl`
+- Includes:
+  - `[#include "/WEB-INF/global/pages/header.ftl" /]`
+  - `[#include "/WEB-INF/global/pages/main-menu.ftl" /]`
+  - `[#include "/WEB-INF/global/pages/footer.ftl" /]`
+- Imports:
+  - `[#import "/WEB-INF/crp/macros/projectsListTemplate.ftl" as projectList /]`
+  - `[#import "/WEB-INF/global/macros/homeDashboard.ftl" as indicatorLists /]`
+- Component calls:
+  - `[@projectList.dashboardProjectsList ... /]`
+  - `[@indicatorLists.deliverablesHomeList ... /]`
+
+## Flow B: POWB Financial Plan
+- Main view: `marlo-web/src/main/webapp/WEB-INF/crp/views/powb/powb_financialPlan.ftl`
+- Includes:
+  - global layout: header/main-menu/footer
+  - POWB partials: `submenu-powb.ftl`, `menu-powb.ftl`, `messages-powb.ftl`, `buttons-powb.ftl`
+- Imports:
+  - `[#import "/WEB-INF/crp/views/powb/macros-powb.ftl" as powbMacros /]`
+- Macro/component usage:
+  - Form controls via `forms.ftl` alias `customForm` (inherited from header import)
+  - `[@customForm.textArea ... /]`, `[@customForm.input ... /]`
+  - `[@powbMacros.projectBudgetsByFlagshipMacro ... /]`
+
+## Flow C: Admin Portfolios Management
+- Main view: `marlo-web/src/main/webapp/WEB-INF/crp/views/admin/portfoliosManagement.ftl`
+- Includes:
+  - `header.ftl`, `breadcrumb.ftl`, `generalMessages.ftl`, `menu-admin.ftl`, `footer.ftl`
+- Local template macro in same file:
+  - `[#macro feedbackCommentFieldsMacro ... isTemplate=false]`
+  - template instance: `[@feedbackCommentFieldsMacro element={} ... isTemplate=true /]`
+- Component usage:
+  - `[@customForm.input ... /]`
+  - `[@customForm.select ... /]`
+
+## forms.ftl Usage Pattern
+- Source macro library: `marlo-web/src/main/webapp/WEB-INF/global/macros/forms.ftl`
+- Common macros used across sections:
+  - `input`, `textArea`, `select`, `checkbox`, `radioButtonGroup`
+- Binding convention:
+  - Input names mirror Struts model paths (example: `powbSynthesis.financialPlan.financialPlanIssues`).
+
+## Implementation Notes for AI
+1. Default approach for UI changes: reuse existing macros from `forms.ftl` before adding raw HTML fields.
+2. For expandable/dynamic blocks, follow `isTemplate=true` + hidden DOM template pattern.
+3. Keep composition in FTL layer (includes/imports) and avoid introducing new rendering stacks.

--- a/reports/ai-context/interceptor-validator-playbook.md
+++ b/reports/ai-context/interceptor-validator-playbook.md
@@ -1,0 +1,56 @@
+# Interceptor and Validator Playbook
+
+## Goal
+Provide a fast decision guide to trace save failures across interceptor stacks, `Action.validate()`, and validator classes.
+
+## Save Pipeline
+1. Route hits Struts action mapping in `struts-*.xml`.
+2. Interceptor stack runs first (auth, session context, section access, edit permission).
+3. `Action.validate()` executes when Struts invokes validation phase.
+4. Most actions guard validation with `if (save) { ... }`.
+5. Validator populates invalid fields/action errors.
+6. Save path uses these errors to block persistence and return input.
+
+## Verified Patterns in Critical Actions
+
+| Action Class | validate() behavior | Validator class | Notes |
+|---|---|---|---|
+| `ProjectDescriptionAction` | `if (save) validator.validate(this, project, true)` | `ProjectDescriptionValidator` | Standard Projects section pattern |
+| `ProjectPartnerAction` | `if (save) projectPartnersValidator.validate(...)` | `ProjectPartnersValidator` | Returns `hasErrors` and blocks save path |
+| `DeliverableAction` | `if (save) deliverableValidator.validate(...)` | `DeliverableValidator` | Uses extended stack sequence (`editProjectListStack` + `editDeliverable`) |
+| `FinancialPlanAction` | `if (save) validator.validate(this, powbSynthesis, true)` | `FinancialPlanValidator` | POWB synthesis save flow |
+| `OutcomesAction` | `if (save) validator.validate(this, outcomes, selectedProgram, true)` | `OutcomeValidator` | Impact pathway save flow |
+| `MeliaAction` | `if (save) validator.validate(this, reportSynthesis, true)` | `MeliaValidator` | Annual report synthesis flow |
+| `PortfolioManagementAction` | `if (save) { }` (empty body) | none in action | Admin action with no explicit validator call |
+
+## Interceptor Stack Intent Map
+1. `editProjectsStack`: project edit permission (`canEditProject`) + stage and session constraints.
+2. `editFSStack`: funding-specific edit guard (`editFunding`).
+3. `editPowbStack`: synthesis-specific edit guard (`canEditPowbSynthesis`).
+4. `editReportSynthesisStack`: annual report edit guard (`canEditReportSynthesis`).
+5. `impactPathwayStack`: impact pathway edit guard (`canEditImpactPathway`).
+6. `crpAdminStack`: admin section access (`accessibleAdmin`, `canEditCrpAdmin`).
+
+## Debugging Checklist for Save Failures
+1. Confirm action route and stack in the corresponding `struts-*.xml` file.
+2. Verify request includes `save=true` when expecting validator execution.
+3. Inspect action `validate()` for the exact validator call and parameters.
+4. Inspect invalid fields and action messages after submit.
+5. Verify permission interceptor in stack (`canEdit*`, `editFunding`, `accessibleAdmin`).
+6. If validator is missing (for example `PortfolioManagementAction`), review action-side checks before changing behavior.
+
+## Common Pitfalls
+1. Assuming validator runs without `save` flag.
+2. Focusing on validator first when interceptor denied access earlier.
+3. Treating all stacks as equivalent; each module has different edit gate interceptor.
+4. Applying JSON assumptions to `.do` actions that use standard form submit flow.
+
+## Source References
+- `marlo-web/src/main/resources/struts.xml`
+- `marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/projects/ProjectDescriptionAction.java`
+- `marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/projects/ProjectPartnerAction.java`
+- `marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/projects/DeliverableAction.java`
+- `marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/powb/FinancialPlanAction.java`
+- `marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/impactpathway/OutcomesAction.java`
+- `marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/annualReport/MeliaAction.java`
+- `marlo-web/src/main/java/org/cgiar/ccafs/marlo/action/crp/admin/PortfolioManagementAction.java`

--- a/reports/ai-context/persistence-replication-managerimpl.md
+++ b/reports/ai-context/persistence-replication-managerimpl.md
@@ -1,0 +1,55 @@
+# Persistence Replication in ManagerImpl
+
+## Goal
+Document how save operations replicate across phases in manager implementation logic.
+
+## Primary Verified Case
+### Deliverable Funding Source Replication
+- File: `marlo-data/src/main/java/org/cgiar/ccafs/marlo/data/manager/impl/DeliverableFundingSourceManagerImpl.java`
+
+### Save flow
+1. `saveDeliverableFundingSource(...)` persists current entity.
+2. Reads current phase (`phaseDao.find(...)`).
+3. If phase is `PLANNING` and has next phase, replication is triggered with `addDeliverableFundingSourcePhase(...)`.
+4. If phase is `REPORTING`, replication targets upkeep phase (`currentPhase.getNext().getNext()`) when available.
+5. Replication recurses through subsequent phases (`if (phase.getNext() != null) ...`).
+
+### Delete flow parity
+1. `deleteDeliverableFundingSource(...)` removes current record.
+2. Applies phase-aware delete propagation:
+   - from `PLANNING` to next phases
+   - from `REPORTING` to upkeep chain
+3. Recurses with `deleteDeliverableFundingSource(...)` across phase chain.
+
+### Constraints in logic
+- Publication-specific condition: replication is skipped for publication deliverables (`isPublication`).
+- Duplicate prevention: target phase list is filtered before insert.
+
+## Additional Verified Replication Patterns
+1. `ProjectInnovationOrganizationManagerImpl`
+   - phase-aware save/delete propagation methods:
+   - `saveInnovationOrganizationPhase(...)`
+   - `deleteProjectInnovationOrganizationPhase(...)`
+2. `ProjectInnovationComplementarySolutionManagerImpl`
+   - phase-aware save/delete propagation methods:
+   - `saveProjectInnovationComplementarySolutionPhase(...)`
+   - `deleteProjectInnovationComplementarySolutionPhase(...)`
+
+## Standard Pattern to Expect in MARLO ManagerImpl
+1. Determine current phase (`PLANNING` or `REPORTING`).
+2. Compute target phase(s): next or upkeep (`next.next`).
+3. Clone or remove related entities in target phases.
+4. Recurse while `phase.getNext() != null`.
+
+## Risk Checklist for Changes
+1. Do not break recursive propagation guards (`phase.getNext()`).
+2. Keep parity between save and delete replication paths.
+3. Preserve duplicate filters when cloning.
+4. Validate publication or section-specific skip rules.
+5. Recheck downstream phase consistency after any manager change.
+
+## Expected Behavior by Phase
+- Planning save: record replicated to all next phases.
+- Planning delete: record removed from all next phases.
+- Reporting save: record replicated to upkeep phase (`next.next`).
+- Reporting delete: record removed from upkeep phase chain.

--- a/reports/ai-context/save-validation-matrix.md
+++ b/reports/ai-context/save-validation-matrix.md
@@ -1,0 +1,34 @@
+# Save Validation Matrix
+
+## Scope
+Validation path for critical save sections:
+`Action (.do)` -> `Interceptor stack` -> `Action.validate()` -> `Validator` -> save block/continue.
+
+## Matrix (10 critical sections)
+
+| Section | Route / Action | Struts Mapping + Stack | Action validate() | Validator call | Save-block behavior |
+|---|---|---|---|---|---|
+| Projects Description | `{crp}/description` -> `ProjectDescriptionAction` | `struts-projects.xml`, `editProjectsStack` | yes (`if (save)`) | `ProjectDescriptionValidator` -> `validator.validate(this, project, true)` | invalid fields/errors block save |
+| Project Partners | `{crp}/partners` -> `ProjectPartnerAction` | `struts-projects.xml`, `editProjectsStack` | yes (`if (save)`) | `ProjectPartnersValidator` -> `projectPartnersValidator.validate(this, project, true)` | returns `hasErrors`; save flow guarded |
+| Deliverable | `{crp}/deliverable` -> `DeliverableAction` | `struts-projects.xml`, `editProjectListStack` + `editDeliverable` + `defaultStack` | yes (`if (save)`) | `DeliverableValidator` -> `deliverableValidator.validate(this, deliverable, true)` | invalid field map and action errors block save |
+| Funding Source | `{crp}/fundingSource` -> `FundingSourceAction` | `struts-fundingSources.xml`, `editFSStack` | yes (`if (save)`) | `FundingSourceValidator` -> `validator.validate(this, fundingSource, true)` | invalid data blocks save |
+| POWB Financial Plan | `{crp}/financialPlan` -> `FinancialPlanAction` | `struts-powb.xml`, `editPowbStack` | yes (`if (save)`) | `FinancialPlanValidator` -> `validator.validate(this, powbSynthesis, true)` | invalid data blocks save |
+| POWB Management Governance | `{crp}/managementGovernance` -> `ManagementGovernanceAction` | `struts-powb.xml`, `editPowbStack` | yes (`if (save)`) | `ManagementGovernanceValidator` -> `validator.validate(this, powbSynthesis, true)` | invalid data blocks save |
+| Impact Pathway Outcomes | `{crp}/outcomes` -> `OutcomesAction` | `struts-impactPathway.xml`, `impactPathwayStack` | yes (`if (save)`) | `OutcomeValidator` -> `validator.validate(this, outcomes, selectedProgram, true)` | invalid data blocks save |
+| Annual Report MELIA | `{crp}/melia` -> `MeliaAction` | `struts-annualReport.xml`, `editReportSynthesisStack` | yes (`if (save)`) | `MeliaValidator` -> `validator.validate(this, reportSynthesis, true)` | invalid data blocks save |
+| Annual Report Governance | `{crp}/governance` -> `ManagementGovernanceAction` | `struts-annualReport.xml`, `editReportSynthesisStack` | yes (`if (save)`) | `GovernanceValidator` -> `validator.validate(this, reportSynthesis, true)` | invalid data blocks save |
+| Admin Portfolio Management | `{crp}/portfolioManagement` -> `PortfolioManagementAction` | `struts-admin.xml`, `crpAdminStack` | validate method present but no validator call | none | currently relies on action-side checks/logic |
+
+## Notes
+1. Interceptor stack is the first gate (auth/session/edit rights).
+2. `save` flag controls whether section validation is executed.
+3. A non-empty invalid field set or action errors should be treated as save blockers.
+4. Sections without explicit validator call (Portfolio Management) should be reviewed before complex changes.
+
+## Key References
+- `marlo-web/src/main/resources/struts-projects.xml`
+- `marlo-web/src/main/resources/struts-fundingSources.xml`
+- `marlo-web/src/main/resources/struts-powb.xml`
+- `marlo-web/src/main/resources/struts-impactPathway.xml`
+- `marlo-web/src/main/resources/struts-annualReport.xml`
+- `marlo-web/src/main/resources/struts-admin.xml`

--- a/reports/ai-context/struts-critical-routing-catalog.md
+++ b/reports/ai-context/struts-critical-routing-catalog.md
@@ -1,0 +1,45 @@
+# Struts Critical Routing Catalog
+
+## Scope
+Operational routing catalog for MARLO internal flows using Struts Actions (`.do`) and Struts JSON (`.json`) only when explicitly configured.
+
+## Global Routing Rules
+1. `struts.action.extension = do,,json` allows `.do` and `.json` routes.
+2. `struts.action.excludePattern = /api/*` keeps Spring MVC API outside Struts internal routing.
+3. Internal module routing should prioritize Struts action mappings in `struts-*.xml` files.
+
+## Critical Modules Catalog
+
+| Module | Struts Package / Namespace | Representative Action Route | Action Class | Interceptor Stack | View Result |
+|---|---|---|---|---|---|
+| Projects | `projects` / `/projects` | `{crp}/description` | `ProjectDescriptionAction` | `editProjectsStack` | `/WEB-INF/crp/views/projects/projectDescription.ftl` |
+| Projects | `projects` / `/projects` | `{crp}/partners` | `ProjectPartnerAction` | `editProjectsStack` | `/WEB-INF/crp/views/projects/projectPartners.ftl` |
+| Projects | `projects` / `/projects` | `{crp}/deliverable` | `DeliverableAction` | `editProjectListStack` + `editDeliverable` + `defaultStack` | `/WEB-INF/crp/views/projects/projectDeliverable.ftl` |
+| Funding Sources | `fundingSources` / `/fundingSources` | `{crp}/fundingSource` | `FundingSourceAction` | `editFSStack` | `/WEB-INF/crp/views/fundingSources/fundingSource.ftl` |
+| POWB | `powb` / `/powb` | `{crp}/financialPlan` | `FinancialPlanAction` | `editPowbStack` | `/WEB-INF/crp/views/powb/powb_financialPlan.ftl` |
+| POWB | `powb` / `/powb` | `{crp}/managementGovernance` | `ManagementGovernanceAction` | `editPowbStack` | `/WEB-INF/crp/views/powb/powb_managementGovernance.ftl` |
+| Impact Pathway | `impactPathway` / `/impactPathway` | `{crp}/outcomes` | `OutcomesAction` | `impactPathwayStack` | `/WEB-INF/crp/views/impactPathway/outcomes.ftl` |
+| Annual Report | `annualReport` / `/annualReport` | `{crp}/melia` | `MeliaAction` | `editReportSynthesisStack` | `/WEB-INF/crp/views/annualReport/annualReport_melia.ftl` |
+| Annual Report | `annualReport` / `/annualReport` | `{crp}/governance` | `ManagementGovernanceAction` | `editReportSynthesisStack` | `/WEB-INF/crp/views/annualReport/annualReport_governance.ftl` |
+| Admin | `admin` / `/admin` | `{crp}/portfolioManagement` | `PortfolioManagementAction` | `crpAdminStack` | `/WEB-INF/crp/views/admin/portfoliosManagement.ftl` |
+
+## Interceptor Stack Pointers
+1. `crpAdminStack`: includes auth/session + admin access + `canEditCrpAdmin`.
+2. `impactPathwayStack`: includes auth/session + `canEditImpactPathway`.
+3. `editProjectsStack`: includes auth/session + `canEditProject`.
+4. `editFSStack`: includes auth/session + `editFunding`.
+5. `editPowbStack`: includes auth/session + `canEditPowbSynthesis`.
+6. `editReportSynthesisStack`: includes auth/session + `canEditReportSynthesis`.
+7. `editProjectListStack`: lightweight stack used before extra action-level interceptors like `editDeliverable`.
+
+## JSON Usage Note
+`projectListStack` includes `SecurityControl` and is the key stack for JSON security checks. Use it only for existing JSON endpoints and avoid introducing new JSON paths unless required by current architecture.
+
+## Source References
+- `marlo-web/src/main/resources/struts.xml`
+- `marlo-web/src/main/resources/struts-projects.xml`
+- `marlo-web/src/main/resources/struts-fundingSources.xml`
+- `marlo-web/src/main/resources/struts-powb.xml`
+- `marlo-web/src/main/resources/struts-impactPathway.xml`
+- `marlo-web/src/main/resources/struts-annualReport.xml`
+- `marlo-web/src/main/resources/struts-admin.xml`


### PR DESCRIPTION
This pull request introduces major improvements to the documentation and workflow guidance for contributors and AI agents working on the MARLO project. The most significant changes include the addition of a dedicated guide for AI assistants, a comprehensive workflow for implementing feature flags ("specificities"), and new references to operational context documentation. These updates aim to standardize development practices, clarify the process for adding new features, and ensure alignment with the project's spec-driven methodology.

**AI Agent & Contributor Documentation:**

- Added a new `CLAUDE.md` file serving as the entry point and constitutional baseline for AI assistants and contributors, outlining required reading order, spec taxonomy, hard rules, and the process for constitutional changes.
- The new guide links to all critical operational, product, and technical documents, and provides a decision framework for common development tasks.

**Feature Flag (Specificity) Workflow:**

- Added a detailed "Specificity Implementation Guide" to `AGENTS.md`, describing a step-by-step process for adding new feature flags based on the `parameters` and `custom_parameters` tables, including migration templates, constant definitions, backend/frontend usage, and a validation checklist.

**Operational Context References:**

- Added a new section in `AGENTS.md` listing authoritative operational context documents for key areas (frontend composition, validation, persistence, routing, interceptors), and clarified the boundaries for Struts and Spring MVC usage.

These changes provide a clear, unified process for both human and AI contributors, reduce ambiguity in critical workflows, and strengthen the project's governance and maintainability.