### PR TITLE
Fix HTML tags shown as text in Progress to Target indicators

### DIFF
--- a/marlo-web/src/main/webapp/WEB-INF/crp/views/impactPathway/outcomes.ftl
+++ b/marlo-web/src/main/webapp/WEB-INF/crp/views/impactPathway/outcomes.ftl
@@ -666,10 +666,11 @@
     <input type="hidden"  name="${customName}.composeID" value="${(indicator.composeID)!}"/>
 
     [#if editable]
-      [@customForm.textArea name="${customName}.indicator" value=indicator.title i18nkey="baselineIndicator.title" showTitle=true className="statement limitWords-50" required=true editable=editable allowTextEditor=true/]
+      [@customForm.textArea name="${customName}.indicator" value=(indicator.indicator)! i18nkey="baselineIndicator.title" showTitle=true className="statement limitWords-50" required=true editable=editable allowTextEditor=true/]
     [#else]
       [#if indicator.indicator?has_content]
-        <div class="input"><p>${(indicator.indicator)!}</p></div>
+        [#-- decodeHTML turns escaped markup into rendered HTML (same pattern as customForm.textArea + allowTextEditor) --]
+        <div class="input"><p class="decodeHTML trumbowyg-editor">${(indicator.indicator)!}</p></div>
       [/#if]
     [/#if]
     <div class="clearfix"></div>

--- a/marlo-web/src/main/webapp/WEB-INF/crp/views/projects/projectContributionCrp.ftl
+++ b/marlo-web/src/main/webapp/WEB-INF/crp/views/projects/projectContributionCrp.ftl
@@ -1190,7 +1190,7 @@
       <span class="index">${index+1}</span>
     </div>
     <div class="form-group grayBox">
-      <strong>${element.indicator}</strong>
+      <div class="decodeHTML trumbowyg-editor">${(element.indicator)!}</div>
     </div>
     <input type="hidden" name="${customName}.id" value="${(projectOutcomeIndicator.id)!}" >
     <input type="hidden" name="${customName}.crpProgramOutcomeIndicator.id" value="${(projectOutcomeIndicator.crpProgramOutcomeIndicator.id)!}" >
@@ -1226,7 +1226,7 @@
       <span class="index">${index+1}</span>
     </div>
     <div class="form-group grayBox">
-      ${(element.indicator)!}
+      <div class="decodeHTML trumbowyg-editor">${(element.indicator)!}</div>
     </div>
     <input type="hidden" name="${customName}.id" value="${(projectOutcomeIndicator.id)!}" >
     <input type="hidden" name="${customName}.crpProgramOutcomeIndicator.id" value="${(projectOutcomeIndicator.crpProgramOutcomeIndicator.id)!}" >
@@ -1269,7 +1269,7 @@
       <span class="index">${index+1}</span>
     </div>
     <div class="form-group grayBox">
-      <strong>${element.indicator}</strong>
+      <div class="decodeHTML trumbowyg-editor">${(element.indicator)!}</div>
     </div>
     <input type="hidden" name="${customName}.id" value="${(projectOutcomePrevIndicator.id)!}" >
     <input type="hidden" name="${customName}.crpProgramOutcomeIndicator.id" value="${(projectOutcomePrevIndicator.crpProgramOutcomeIndicator.id)!}" >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Progress to Target indicator cards were showing raw HTML tags instead of rendering rich-text formatting.
- Applied the existing `decodeHTML` / `trumbowyg-editor` pattern in Impact Pathway Outcomes (read-only) and Project Contribution indicator cards.
- Corrected editable Outcomes binding from `indicator.title` to `indicator.indicator`.

## Branching
- Feature branch created from `aiccra-staging`.
- Target: merge back into `aiccra-staging` (protected branch requires PR).

## Test plan
- [ ] Impact Pathway → Outcomes → Progress to Target indicators (read-only): formatted HTML, no visible tags
- [ ] Same section in edit mode: rich-text editor loads indicator content
- [ ] Project Contribution AICCRA: indicator text in gray boxes renders as HTML

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6b56-7d61-77d9-875e-e90a76ed2202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6b56-7d61-77d9-875e-e90a76ed2202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

