### PR TITLE
Fix Progress to Target indicators rendering HTML as plain text

### DIFF
--- a/marlo-web/src/main/webapp/WEB-INF/crp/views/impactPathway/outcomes.ftl
+++ b/marlo-web/src/main/webapp/WEB-INF/crp/views/impactPathway/outcomes.ftl
@@ -666,10 +666,11 @@
     <input type="hidden"  name="${customName}.composeID" value="${(indicator.composeID)!}"/>
 
     [#if editable]
-      [@customForm.textArea name="${customName}.indicator" value=indicator.title i18nkey="baselineIndicator.title" showTitle=true className="statement limitWords-50" required=true editable=editable allowTextEditor=true/]
+      [@customForm.textArea name="${customName}.indicator" value=(indicator.indicator)! i18nkey="baselineIndicator.title" showTitle=true className="statement limitWords-50" required=true editable=editable allowTextEditor=true/]
     [#else]
       [#if indicator.indicator?has_content]
-        <div class="input"><p>${(indicator.indicator)!}</p></div>
+        [#-- decodeHTML turns escaped markup into rendered HTML (same pattern as customForm.textArea + allowTextEditor) --]
+        <div class="input"><p class="decodeHTML trumbowyg-editor">${(indicator.indicator)!}</p></div>
       [/#if]
     [/#if]
     <div class="clearfix"></div>

--- a/marlo-web/src/main/webapp/WEB-INF/crp/views/projects/projectContributionCrp.ftl
+++ b/marlo-web/src/main/webapp/WEB-INF/crp/views/projects/projectContributionCrp.ftl
@@ -1190,7 +1190,7 @@
       <span class="index">${index+1}</span>
     </div>
     <div class="form-group grayBox">
-      <strong>${element.indicator}</strong>
+      <div class="decodeHTML trumbowyg-editor">${(element.indicator)!}</div>
     </div>
     <input type="hidden" name="${customName}.id" value="${(projectOutcomeIndicator.id)!}" >
     <input type="hidden" name="${customName}.crpProgramOutcomeIndicator.id" value="${(projectOutcomeIndicator.crpProgramOutcomeIndicator.id)!}" >
@@ -1226,7 +1226,7 @@
       <span class="index">${index+1}</span>
     </div>
     <div class="form-group grayBox">
-      ${(element.indicator)!}
+      <div class="decodeHTML trumbowyg-editor">${(element.indicator)!}</div>
     </div>
     <input type="hidden" name="${customName}.id" value="${(projectOutcomeIndicator.id)!}" >
     <input type="hidden" name="${customName}.crpProgramOutcomeIndicator.id" value="${(projectOutcomeIndicator.crpProgramOutcomeIndicator.id)!}" >
@@ -1269,7 +1269,7 @@
       <span class="index">${index+1}</span>
     </div>
     <div class="form-group grayBox">
-      <strong>${element.indicator}</strong>
+      <div class="decodeHTML trumbowyg-editor">${(element.indicator)!}</div>
     </div>
     <input type="hidden" name="${customName}.id" value="${(projectOutcomePrevIndicator.id)!}" >
     <input type="hidden" name="${customName}.crpProgramOutcomeIndicator.id" value="${(projectOutcomePrevIndicator.crpProgramOutcomeIndicator.id)!}" >


### PR DESCRIPTION
Apply the existing decodeHTML pattern so rich-text indicator content is rendered instead of showing raw tags in Impact Pathway outcomes and project contribution cards. Also bind the editor value to indicator.indicator.